### PR TITLE
Support DeferredConfig-like objects

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -723,6 +723,10 @@ util.loadFileConfigs = function() {
   return config;
 };
 
+function isDeferredConfig(value) {
+  return value instanceof DeferredConfig || (typeof value == 'object' && typeof value.resolve == 'function');
+}
+
 // Using basic recursion pattern, find all the deferred values and resolve them.
 util.resolveDeferredConfigs = function (config) {
     var completeConfig = config;
@@ -737,8 +741,8 @@ util.resolveDeferredConfigs = function (config) {
                       _iterate(prop[property][i]);
                   }
               } else {
-                  if (prop[property] instanceof DeferredConfig ) {
-                    prop[property]= prop[property].resolve.call(completeConfig,completeConfig)
+                  if (isDeferredConfig(prop[property])) {
+                    prop[property]= prop[property].resolve.call(completeConfig,completeConfig);
                   }
                   else {
                     // Nothing to do. Keep the property how it is.

--- a/test/3-config/default.js
+++ b/test/3-config/default.js
@@ -8,6 +8,11 @@ var config = {
 
 };
 
+function DeferLike() {}
+DeferLike.prototype.resolve = function() {
+  return "cFunc resolved!";
+};
+
 // Set up a default value which refers to another value.
 // The resolution of the value is deferred until all the config files have been loaded
 // So that if 'config.siteTitle' is overridden, this will point to the correct value.
@@ -19,6 +24,14 @@ config.welcomeEmail = {
   aFunc  : function () {
     return "Still just a function.";
   },
+  // plain objects with a resolve function are still a function
+  bFunc : {
+    resolve: function() {
+      return "Still just a function.";
+    }
+  },
+  // proper objects with a resolve function are resolved
+  cFunc : Object.create(DeferLike.prototype),
 
   // Look ma, no arg passing. The main config object is bound to 'this'
   justThis: defer(function () {

--- a/test/3-deferred-configs.js
+++ b/test/3-deferred-configs.js
@@ -32,6 +32,16 @@ vows.describe('Tests for deferred values').addBatch({
         assert.equal(CONFIG.welcomeEmail.aFunc(), 'Still just a function.');
     },
 
+    'values which are named "resolve" functions remain untouched unless they are proper objects': function() {
+        // If this had been treated as a deferred config value it would blow-up.
+        assert.equal(CONFIG.welcomeEmail.bFunc.resolve(), 'Still just a function.');
+    },
+
+    'values which are DeferredConfig-like objects, should be evaluated': function() {
+        // If this had been treated as a deferred config value it would blow-up.
+        assert.equal(CONFIG.welcomeEmail.cFunc, 'cFunc resolved!');
+    },
+
     // This defer function didn't use args, but relied 'this' being bound to the main config object
     "defer functions can simply refer to 'this'" : function () {
         assert.equal(CONFIG.welcomeEmail.justThis, 'Welcome to this New Instance!');


### PR DESCRIPTION
So the scenario I'm trying to support is very much an edgecase, but hear me out. I have a modularized project, where the root project is sucking in code from various sub node_modules, which include their own config settings. The problem I have is that each project has it's own copy of node-config, so when I suck in their config, all DeferredConfig objects don't match the `instanceof DeferredConfig` check in the project and they don't get resolved. This just allows non-object objects with a resolve function to be treated like a DeferredConfig object. 

Thoughts?
