### PR TITLE
Config object must not be extendable after first call to get() 

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -566,6 +566,9 @@ util.makeImmutable = function(object, property, value) {
     }
   }
 
+  // Make sure new properties cannot be added in the future
+  Object.preventExtensions(object);
+
   return object;
 };
 

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -124,25 +124,18 @@ vows.describe('Test suite for node-config')
       assert.equal(CONFIG.MuteThis, 'world');
     },
 
-    'No mutation after the first get()': function () {
-      assert.equal(CONFIG.get('MuteThis'), 'world');
-      CONFIG.MuteThis = 'backToHello';
-      assert.equal(CONFIG.MuteThis, 'world');
-    }
-  },
-
-  'Extensibility': {
-    'Correct ExtendThis setup var': function () {
-      assert.deepEqual(CONFIG.ExtendThis, {});
-    },
-
     'Added props sticks': function () {
       CONFIG.ExtendThis.hello = 'world';
       assert.equal(CONFIG.ExtendThis.hello, 'world');
     },
 
     'No mutation after the first get()': function () {
-      assert.equal(CONFIG.get('ExtendThis.hello'), 'world');
+      assert.equal(CONFIG.get('MuteThis'), 'world');
+      CONFIG.MuteThis = 'backToHello';
+      assert.equal(CONFIG.MuteThis, 'world');
+    },
+
+    'No extensions after the first get()': function () {
       CONFIG.ExtendThis.newProp = 'shouldNotStick';
       assert.equal(CONFIG.ExtendThis.hello, 'world');
       assert.equal(typeof CONFIG.ExtendThis.newProp, 'undefined');

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -131,6 +131,24 @@ vows.describe('Test suite for node-config')
     }
   },
 
+  'Extensibility': {
+    'Correct ExtendThis setup var': function () {
+      assert.deepEqual(CONFIG.ExtendThis, {});
+    },
+
+    'Added props sticks': function () {
+      CONFIG.ExtendThis.hello = 'world';
+      assert.equal(CONFIG.ExtendThis.hello, 'world');
+    },
+
+    'No mutation after the first get()': function () {
+      assert.equal(CONFIG.get('ExtendThis.hello'), 'world');
+      CONFIG.ExtendThis.newProp = 'shouldNotStick';
+      assert.equal(CONFIG.ExtendThis.hello, 'world');
+      assert.equal(typeof CONFIG.ExtendThis.newProp, 'undefined');
+    }
+  },
+
   'Configurations from the $NODE_CONFIG environment variable': {
     'Configuration can come from the $NODE_CONFIG environment': function() {
       assert.equal(CONFIG.EnvOverride.parm3, 'overridden from $NODE_CONFIG');

--- a/test/config/default.js
+++ b/test/config/default.js
@@ -19,6 +19,7 @@ module.exports = {
     parm2: 22
   },
   MuteThis: 'hello',
+  ExtendThis: {},
   get customerDbPort() {
     return '' + this.Customers.dbPort;
   },


### PR DESCRIPTION
For #471 