### PR TITLE
Add NODE_CONFIG_RUNTIME process.env variable to completely overwrite all config data

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -16,7 +16,7 @@ var deferConfig = require('../defer').deferConfig,
 var DEFAULT_CLONE_DEPTH = 20,
     NODE_CONFIG, CONFIG_DIR, RUNTIME_JSON_FILENAME, NODE_ENV, APP_INSTANCE,
     HOST, HOSTNAME, ALLOW_CONFIG_MUTATIONS, CONFIG_SKIP_GITCRYPT,
-    NODE_CONFIG_PARSER,
+    NODE_CONFIG_PARSER, NODE_CONFIG_RUNTIME,
     env = {},
     privateUtil = {},
     deprecationWarnings = {},
@@ -508,11 +508,6 @@ util.getConfigSources = function() {
  * @return config {Object} The configuration object
  */
 util.loadFileConfigs = function(configDir) {
-
-  // Initialize
-  var t = this,
-      config = {};
-
   // Initialize parameters from command line, environment, or default
   NODE_ENV = util.initParam('NODE_ENV', 'development');
 
@@ -521,6 +516,29 @@ util.loadFileConfigs = function(configDir) {
 
   // Split files name, for loading multiple files.
   NODE_ENV = NODE_ENV.split(',');
+
+  // Completely Override configurations from the $NODE_CONFIG_RUNTIME environment variable
+  if (!configDir) {
+    NODE_CONFIG_RUNTIME = process.env.NODE_CONFIG_RUNTIME || undefined;
+    if (NODE_CONFIG_RUNTIME) {
+      try {
+        NODE_CONFIG_RUNTIME = JSON.parse(NODE_CONFIG_RUNTIME);
+      } catch(e) {
+        NODE_CONFIG_RUNTIME = undefined;
+        console.error('The $NODE_CONFIG_RUNTIME environment variable is malformed JSON');
+        throw new Error('Wrong NODE_CONFIG_RUNTIME');
+      }
+      configSources.push({
+        name: "$NODE_CONFIG_RUNTIME",
+        parsed: NODE_CONFIG_RUNTIME,
+      });
+    }
+    return NODE_CONFIG_RUNTIME;
+  }
+
+  // Initialize
+  var t = this,
+      config = {};
 
   CONFIG_DIR = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
   if (CONFIG_DIR.indexOf('.') === 0) {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "node": ">= 6.0.0"
   },
   "scripts": {
-    "test": "./node_modules/vows/bin/vows test/*.js --spec"
+    "test": "vows test/*.js --spec"
   }
 }


### PR DESCRIPTION
process.env.NODE_CONFIG_RUNTIME runtime variable can only overwrite on top of config data after being loaded from files. 

We need a process.env variable that can completely bypass config files loading process. So that we could create json file in the build time and only upload compiled config data to servers.

Also with new process.env.NODE_CONFIG_RUNTIME variable, we could use `webpack.DefinePlugin` to ship bundled artifact without copy all files under config folder.