### PR TITLE
feat: add SUPPRESS_STRICTNESS_CHECK to stop runStrictnessChecks

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1453,6 +1453,11 @@ util.toObject = function(config) {
 
 // Run strictness checks on NODE_ENV and NODE_APP_INSTANCE and throw an error if there's a problem.
 util.runStrictnessChecks = function (config) {
+  var noCheck = util.initParam('SUPPRESS_STRICTNESS_CHECK');
+  if (noCheck) {
+    return;
+  }
+
   var sources = config.util.getConfigSources();
 
   var sourceFilenames = sources.map(function (src) {


### PR DESCRIPTION
I only need use config.util.loadFileConfig to load multi config directories.  But now it always runs strictness checks when node-config is required and there are warnings as following:

<img width="790" alt="image" src="https://user-images.githubusercontent.com/3810606/173192844-00d73f8c-5aae-4bc0-aa90-9cf00852644e.png">


So add env "SUPPRESS_STRICTNESS_CHECK" to stop running strictness checks 
