### PR TITLE
Support loading transpiled JS config files

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -1,4 +1,5 @@
 // External libraries are lazy-loaded only if these file types exist.
+const util = require("util");
 var Yaml = null,
     VisionmediaYaml = null,
     Coffee = null,
@@ -48,7 +49,12 @@ Parser.xmlParser = function(filename, content) {
 };
 
 Parser.jsParser = function(filename, content) {
-  return require(filename);
+  var configObject = require(filename);
+
+  if (configObject.__esModule && util.isObject(configObject.default)) {
+    return configObject.default
+  }
+  return configObject;
 };
 
 Parser.tsParser = function(filename, content) {

--- a/test/x-config-js-test-transpiled.js
+++ b/test/x-config-js-test-transpiled.js
@@ -1,0 +1,43 @@
+var requireUncached = require('./_utils/requireUncached');
+
+var vows = require('vows'),
+    assert = require('assert')
+
+var CONFIG;
+vows.describe('Test suite for node-config transpiled JS files')
+.addBatch({
+  'Library initialization with transpiled JavaScript ES6 config files': {
+    topic : function () {
+
+      // Clear after previous tests
+      process.env.NODE_APP_INSTANCE = '';
+      process.env.NODE_ENV = '';
+      process.env.NODE_CONFIG = '';
+
+      // Change the configuration directory for testing
+      process.env.NODE_CONFIG_DIR = __dirname + '/x-config-js-transpiled';
+
+      // Disable after previous tests
+      process.env.NODE_CONFIG_STRICT_MODE = false;
+
+      CONFIG = requireUncached(__dirname + '/../lib/config');
+
+      return CONFIG;
+
+    },
+    'Config library is available': function() {
+      assert.isObject(CONFIG);
+    }
+  },
+})
+.addBatch({
+  'Configuration file Tests': {
+    'Loading configurations from a transpiled JS file is correct': function() {
+      assert.equal(CONFIG.title, 'Hello config!');
+    }
+  },
+})
+.export(module);
+
+
+

--- a/test/x-config-js-transpiled/default.js
+++ b/test/x-config-js-transpiled/default.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var defaultConfig = {
+  title: 'Hello world!'
+};
+exports.default = defaultConfig;

--- a/test/x-config-js-transpiled/local.js
+++ b/test/x-config-js-transpiled/local.js
@@ -1,0 +1,6 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var defaultConfig = {
+    title: 'Hello config!'
+};
+exports.default = defaultConfig;


### PR DESCRIPTION
This pull request aims to finish previously opened pull request #566. Adding support for transpiled JS modules (those with `module.exports = config`) is helpful when you have a `config` directory inside your `src` directory in the `TypeScript` project.

To ensure that the file is transpiled and to preserve backward compatibility, I have added a check for `__esModule` and the `default` property that it is an object.