### PR TITLE
Fix for collision of setModuleDefaults with get(), has() and friends

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -315,14 +315,16 @@ util.makeHidden = function(object, property, value) {
   // If the new value isn't specified, just mark the property as hidden
   if (typeof value === 'undefined') {
     Object.defineProperty(object, property, {
-      enumerable : false
+      enumerable  : false,
+      configurable: true,
     });
   }
   // Otherwise set the value and mark it as hidden
   else {
     Object.defineProperty(object, property, {
-      value      : value,
-      enumerable : false
+      value       : value,
+      enumerable  : false,
+      configurable: true
     });
   }
 
@@ -1314,7 +1316,13 @@ util.extendDeep = function(mergeInto) {
         mergeInto[prop] = mergeFrom[prop];
       }
       // Copy recursively if the mergeFrom element is an object (or array or fn)
-      else if (mergeFrom[prop] && typeof mergeFrom[prop] === 'object') {
+      else if (typeof mergeFrom[prop] === 'object') {
+        let descriptor = Object.getOwnPropertyDescriptor(Object(mergeInto), prop);
+        if (descriptor && descriptor.enumerable === false) {
+          // allow properties that collide with helper functions
+          delete mergeInto[prop];
+        }
+
         mergeInto[prop] = util.cloneDeep(mergeFrom[prop], depth -1);
       }
 

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -434,8 +434,16 @@ vows.describe('Test suite for node-config')
 
       assert.deepEqual(BKTestModuleDefaults.nested, testModuleConfig.get('nested'));
       assert.deepEqual(OtherTestModuleDefaults.other, testSubModuleConfig.OtherTestModule.other);
+    },
+
+    'Prototypes do not mask values provided to setModuleDefaults': function() {
+      MODULE_CONFIG = requireUncached(__dirname + '/../lib/config');
+      MODULE_CONFIG.util.setModuleDefaults("ModuleWithDefaults", { nested: { get: { default: true } } });
+
+      assert.deepEqual(MODULE_CONFIG.ModuleWithDefaults.nested.value, { overridden: true });
+      assert.deepEqual(MODULE_CONFIG.ModuleWithDefaults.nested.get, { default: true });
     }
-  },
+  }
 })
   .addBatch({
     'Library initialization from multiple directories': {

--- a/test/config/default.json
+++ b/test/config/default.json
@@ -8,6 +8,13 @@
   "AnotherModule": {
     "parm1":"value1"
   },
+  "ModuleWithDefaults": {
+    "nested": {
+      "value": {
+        "overridden": true
+      }
+    }
+  },
   "staticArray": [2,1,3],
   "Inline": {"a": "", "b": "1"},
   "ContainsQuote": "\"this has a quote\"",


### PR DESCRIPTION
This PR addresses #689

The problem is that defineProperty() defaults to configurable: false, which should only be false in makeImmutable(). If you set it before that, you can't delete properties or modify the property.