### PR TITLE
Add support for jsonc file extension

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -796,7 +796,7 @@ util.resolveDeferredConfigs = function (config) {
  * .js = File to run that has a module.exports containing the config object
  * .coffee = File to run that has a module.exports with coffee-script containing the config object
  * .iced = File to run that has a module.exports with iced-coffee-script containing the config object
- * All other supported file types (yaml, toml, json, cson, hjson, json5, properties, xml)
+ * All other supported file types (yaml, toml, json, cson, hjson, jsonc, json5, properties, xml)
  * are parsed with util.parseString.
  *
  * If the file doesn't exist, a null will be returned.  If the file can't be
@@ -876,6 +876,7 @@ util.parseFile = function(fullFilename, options) {
  * toml = Parsed with a TOML parser
  * cson = Parsed with a CSON parser
  * hjson = Parsed with a HJSON parser
+ * jsonc = Parsed with a JSON5 parser
  * json5 = Parsed with a JSON5 parser
  * properties = Parsed with the 'properties' node package
  * xml = Parsed with a XML parser

--- a/parser.js
+++ b/parser.js
@@ -314,7 +314,7 @@ Parser.numberParser = function(filename, content) {
   return Number.isNaN(numberValue) ? undefined : numberValue;
 };
 
-var order = ['js', 'cjs', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml',
+var order = ['js', 'cjs', 'ts', 'json', 'jsonc', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml',
   'boolean', 'number'];
 var definitions = {
   cjs: Parser.jsParser,
@@ -324,6 +324,7 @@ var definitions = {
   iced: Parser.icedParser,
   js: Parser.jsParser,
   json: Parser.jsonParser,
+  jsonc: Parser.json5Parser,
   json5: Parser.json5Parser,
   properties: Parser.propertiesParser,
   toml: Parser.tomlParser,

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -112,6 +112,10 @@ vows.describe('Test suite for node-config')
       assert.equal(CONFIG.AnotherModule.parm9, 'value9');
     },
 
+    'Loading configurations from a JSONC file is correct': function() {
+      assert.equal(CONFIG.AnotherModule.parm10, 'value10');
+    },
+
     'Loading configurations from an environment file is correct': function() {
       assert.equal(CONFIG.Customers.dbPort, '5999');
     },

--- a/test/config/default.jsonc
+++ b/test/config/default.jsonc
@@ -1,0 +1,15 @@
+{
+
+  // Comment to test comment ignoring
+
+  "Customers": {
+    "dbName":"from_default_jsonc"
+  },
+  "AnotherModule": {
+    /*
+      Another multiline comment
+    */
+    "parm10":"value10"
+  }
+  
+}


### PR DESCRIPTION
This is another [attempt](https://github.com/node-config/node-config/pull/682) to support `.jsonc` extension but using JSON5 parser as advised in https://github.com/node-config/node-config/issues/671#issuecomment-1039794125