### PR TITLE
fix(vulnerability): upgrade json5 version from 2.2.1 to 2.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "json5": "^2.2.2"
+    "json5": "^2.2.3"
   },
   "devDependencies": {
     "@types/node": "^7.0.8",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "json5": "^2.2.1"
+    "json5": "^2.2.2"
   },
   "devDependencies": {
     "@types/node": "^7.0.8",


### PR DESCRIPTION
json5 dependency is vulnerable in the current version which is `2.2.1`, this PR contains the fix. The vulnerability is resolved in version  `2.2.2`.

This PR resolves the issue #712 