### PR TITLE
Fix source maps when using ts config files, improve performance loading ts config files

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -61,6 +61,7 @@ Parser.tsParser = function(filename, content) {
   if (!require.extensions['.ts']) {
     require(TS_DEP).register({
       lazy: true,
+      ignore: ['(?:^|/)node_modules/', '.*(?<!\.ts)$'],
       transpileOnly: true,
       compilerOptions: {
         allowJs: true,


### PR DESCRIPTION
This PR addresses https://github.com/node-config/node-config/issues/530 and https://github.com/node-config/node-config/issues/613

The problem was that newly registered `ts-node` took over transpilation of all files.
Using `ignore` option we can exclude transpiling again anything that is not a typescript file.

First regex `(?:^|/)node_modules/` is just the default that is used by `ts-node` to exclude `node_modules` if `ignore` option is unspecified.