### PR TITLE
Fix sourcemap issue when using .ts files

### DIFF
--- a/parser.js
+++ b/parser.js
@@ -58,15 +58,6 @@ Parser.jsParser = function(filename, content) {
 };
 
 Parser.tsParser = function(filename, content) {
-  if (!require.extensions['.ts']) {
-    require(TS_DEP).register({
-      lazy: true,
-      transpileOnly: true,
-      compilerOptions: {
-        allowJs: true,
-      }
-    });
-  }
 
   // Imports config if it is exported via module.exports = ...
   // See https://github.com/node-config/node-config/issues/524


### PR DESCRIPTION
This PR addresses https://github.com/node-config/node-config/issues/530

Current Behavior: Config files with a .ts extension breaks sourcemaps for jest resulting in incorrect line reporting for test failures.  

Expected Behavior: The line number for a test failure should be correctly reported.

