### PR TITLE
refactor: 💡 xxx === undefined => typeof xxx === 'undefined'

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -163,7 +163,7 @@ const getImpl= function(object, property) {
  * @return value {*} - The property value
  */
 Config.prototype.get = function(property) {
-  if(property === null || property === undefined){
+  if(property === null || typeof property === "undefined"){
     throw new Error("Calling config.get with null or undefined argument");
   }
 
@@ -178,7 +178,7 @@ Config.prototype.get = function(property) {
   const value = getImpl(t, property);
 
   // Produce an exception if the property doesn't exist
-  if (value === undefined) {
+  if (typeof value === "undefined") {
     throw new Error('Configuration property "' + property + '" is not defined');
   }
 
@@ -202,11 +202,11 @@ Config.prototype.get = function(property) {
  */
 Config.prototype.has = function(property) {
   // While get() throws an exception for undefined input, has() is designed to test validity, so false is appropriate
-  if(property === null || property === undefined){
+  if(property === null || typeof property === "undefined"){
     return false;
   }
   const t = this;
-  return (getImpl(t, property) !== undefined);
+  return typeof getImpl(t, property) !== "undefined";
 };
 
 /**
@@ -471,7 +471,7 @@ util.getConfigSources = function() {
  * @return options[optionName] if defined, defaultValue if not.
  */
 util.getOption = function(options, optionName, defaultValue) {
-  if (options !== undefined && options[optionName] !== undefined){
+  if (options !== undefined && typeof options[optionName] !== 'undefined'){
     return options[optionName];
   } else {
     return defaultValue;
@@ -981,7 +981,7 @@ util.cloneDeep = function cloneDeep(parent, depth, circular, prototype) {
   const allParents = [];
   const allChildren = [];
 
-  const useBuffer = typeof Buffer != 'undefined';
+  const useBuffer = typeof Buffer !== 'undefined';
 
   if (typeof circular === 'undefined')
     circular = true;
@@ -1031,7 +1031,7 @@ util.cloneDeep = function cloneDeep(parent, depth, circular, prototype) {
 
     for (const i in parent) {
       const propDescriptor  = Object.getOwnPropertyDescriptor(parent,i);
-      const hasGetter = ((propDescriptor !== undefined) && (propDescriptor.get !== undefined));
+      const hasGetter = ((typeof propDescriptor !== 'undefined') && (typeof propDescriptor.get !== 'undefined'));
 
       if (hasGetter){
         Object.defineProperty(child,i,propDescriptor);
@@ -1095,12 +1095,12 @@ util.substituteDeep = function (substitutionMap, variables) {
     for (const prop in map) {
       const value = map[prop];
       if (typeof(value) === 'string') { // We found a leaf variable name
-        if (vars[value] !== undefined && vars[value] !== '') { // if the vars provide a value set the value in the result map
+        if (typeof vars[value] !== 'undefined' && vars[value] !== '') { // if the vars provide a value set the value in the result map
           util.setPath(result, pathTo.concat(prop), vars[value]);
         }
       }
       else if (util.isObject(value)) { // work on the subtree, giving it a clone of the pathTo
-        if ('__name' in value && '__format' in value && vars[value.__name] !== undefined && vars[value.__name] !== '') {
+        if ('__name' in value && '__format' in value && typeof vars[value.__name] !== 'undefined' && vars[value.__name] !== '') {
           try {
             const parsedValue = util.parseString(vars[value.__name], value.__format);
           } catch(err) {


### PR DESCRIPTION
Hi there!
Comparing `typeof xxx === 'undefined'` is safer than using `xxx === undefined` because `undefined` is a global variable that can be overwritten.