### PR TITLE
Add convenience method tryGet

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -196,9 +196,6 @@ decValidateGetArgs = function (delegate, myName) {
  * @return value {*} - The property value, or undefined if it does not exist.
  */
 Config.prototype.tryGet = decValidateGetArgs(decCheckMutability(function(property) {
-  if ( property === '' ) {
-    throw new Error('Empty string is not valid when using tryGet');
-  }
   const t = this;
   return getImpl(t, property);
 }), 'tryGet');

--- a/lib/config.js
+++ b/lib/config.js
@@ -150,6 +150,57 @@ const getImpl= function(object, property) {
 };
 
 /**
+ * Decorates a method to trigger mutability check
+ * @param delegate {function} - The method to delegate to
+ * @return result {function} - The composed function
+ */
+const decCheckMutability = function (delegate) {
+  return function () {
+    // Make configurations immutable after first get (unless disabled)
+    if (checkMutability) {
+      if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
+        util.makeImmutable(config);
+      }
+      checkMutability = false;
+    }
+
+    return delegate.apply(this, arguments);
+  }
+}
+
+/**
+ * Decorator for get methods (get, tryGet) to validate the property argument
+ * @param delegate {function} - The method to delegate to
+ * @param myName {string} - The name of the method being decorated (for exception message)
+ * @return result {function} - The composed function
+ */
+decValidateGetArgs = function (delegate, myName) {
+  return function (property) {
+    if(property === null || property === undefined){
+      throw new Error("Calling config."+myName+" with null or undefined argument");
+    }
+    return delegate.apply(this, arguments);
+  }
+}
+
+/**
+ * <p>Get a configuration value and silent fail</p>
+ *
+ * <p>
+ * This performs the same behaviour as get but does not throw an exception if
+ * the configuration parameter does not exist; instead, it will return undefined.
+ * </p>
+ *
+ * @method tryGet
+ * @param property {string} - The configuration property to get. Can include '.' sub-properties.
+ * @return value {*} - The property value, or undefined if it does not exist.
+ */
+Config.prototype.tryGet = decValidateGetArgs(decCheckMutability(function(property) {
+  const t = this;
+  return getImpl(t, property);
+}), 'tryGet');
+
+/**
  * <p>Get a configuration value</p>
  *
  * <p>
@@ -162,18 +213,7 @@ const getImpl= function(object, property) {
  * @param property {string} - The configuration property to get. Can include '.' sub-properties.
  * @return value {*} - The property value
  */
-Config.prototype.get = function(property) {
-  if(property === null || property === undefined){
-    throw new Error("Calling config.get with null or undefined argument");
-  }
-
-  // Make configurations immutable after first get (unless disabled)
-  if (checkMutability) {
-    if (!util.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-      util.makeImmutable(config);
-    }
-    checkMutability = false;
-  }
+Config.prototype.get = decValidateGetArgs(decCheckMutability(function(property) {
   const t = this;
   const value = getImpl(t, property);
 
@@ -184,7 +224,7 @@ Config.prototype.get = function(property) {
 
   // Return the value
   return value;
-};
+}), 'get');
 
 /**
  * Test that a configuration parameter exists

--- a/lib/config.js
+++ b/lib/config.js
@@ -196,6 +196,9 @@ decValidateGetArgs = function (delegate, myName) {
  * @return value {*} - The property value, or undefined if it does not exist.
  */
 Config.prototype.tryGet = decValidateGetArgs(decCheckMutability(function(property) {
+  if ( property === '' ) {
+    throw new Error('Empty string is not valid when using tryGet');
+  }
   const t = this;
   return getImpl(t, property);
 }), 'tryGet');

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -361,11 +361,8 @@ vows.describe('Test suite for node-config')
           /Calling config.tryGet with null or undefined argument/
       );
     },
-    "tryGet('') throws an exception": function() {
-      assert.throws(
-          function () { CONFIG.tryGet(''); },
-          /Empty string is not valid when using tryGet/
-      );
+    "tryGet('') returns undefined": function() {
+      assert.equal(CONFIG.tryGet(''), undefined);
     },
   },
 

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -339,6 +339,36 @@ vows.describe('Test suite for node-config')
     },
   },
 
+  'tryGet() tests': {
+    'The function exists': function() {
+      assert.isFunction(CONFIG.tryGet);
+    },
+    'No exception is thrown on mis-spellings': function() {
+      assert.doesNotThrow(function () { CONFIG.tryGet('mis.spelled'); });
+    },
+    'No exception is thrown on non-objects': function() {
+      assert.doesNotThrow(function () { CONFIG.tryGet('Testmodule.misspelled'); });
+    },
+    'tryGet(undefined) throws an exception': function() {
+      assert.throws(
+          function () { CONFIG.tryGet(undefined); },
+          /Calling config.tryGet with null or undefined argument/
+      );
+    },
+    'tryGet(null) throws an exception': function() {
+      assert.throws(
+          function () { CONFIG.tryGet(null); },
+          /Calling config.tryGet with null or undefined argument/
+      );
+    },
+    "tryGet('') throws an exception": function() {
+      assert.throws(
+          function () { CONFIG.tryGet(''); },
+          /Empty string is not valid when using tryGet/
+      );
+    },
+  },
+
   'has() tests': {
     'The function exists': function() {
       assert.isFunction(CONFIG.has);


### PR DESCRIPTION
- added `tryGet`
- factored out common functionality into decorators
  - `decCheckMutability` adds the checkMutability side-effect to a method
  - `decValidateGetArgs` adds exception on undefined property name
  - `get` and `tryGet` are both decorated with these
- added test for `tryGet`

I decided to make `tryGet` throw an error if it receives `undefined` or `null` as the parameter name. I know `has` has differing behavior, but I _want_ tryGet to throw an exception if I give it an invalid input because that would indicate the code using it has a problem that needs to be fixed.