### PR TITLE
[NODE_CONFIG_DIR issue]Wrong return files in config.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -737,8 +737,8 @@ util.locateMatchingFiles = function(configDirs, allowedFiles) {
           });
         }
         catch(e) {}
-        return files;
       }
+      return files;
     }, [])
     .sort(function(a, b) { return a[0] - b[0]; })
     .map(function(file) { return file[1]; });


### PR DESCRIPTION
I am getting the following error:


```bash
TypeError: Cannot read properties of undefined (reading 'sort') at Config.util.locateMatchingFiles (E:\wamp64\www\configtest\node_modules\.pnpm\config@3.3.9\node_modules\config\lib\config.js:741:5
```
This happens when you configure only one dir in NODE_CONFIG_DIR:
```typescript

process.env["NODE_CONFIG_DIR"] = path.resolve(__dirname,`../environments/${env}`)+path.delimiter;

```


Swap this line for line 741 to solve the issue:

https://github.com/node-config/node-config/blob/46d0c31c4a14e38c115b3eb8807c880d9d1b5f0e/lib/config.js#L740