### PR TITLE
Introduce check-environment-variables.js

### DIFF
--- a/lib/check-environment-variables.js
+++ b/lib/check-environment-variables.js
@@ -1,0 +1,65 @@
+/**
+ * Checks for the presence of environment variables and returns the list of missing ones.
+ *
+ * @param {object} _Config Config object.
+ * @param {object|string} _elt A value representing a subset of the configuration structure,
+ * or a string representing an environment variable name.
+ * @param {string} _path The property configuration path to check (ex: "service.name")
+ * @param {string[]} _missingEnvVariables List of missing environment variables.
+ * @returns {string[]} List of missing environment variables.
+ *@private
+ */
+function recurseCheck(_Config, _elt, _path, _missingEnvVariables) {
+    if (typeof _elt === "object") {
+        for (const propName in _elt) {
+            // The "__name" property represents an environment variable, the value is checked
+            if (propName === "__name") {
+                recurseCheck(_Config, _elt[propName], _path, _missingEnvVariables);
+            // Ignore the "__format" property which should not have an environment variable name as value
+            } else if (propName !== "__format") {
+                const propPath = _path === "" ? propName : `${_path}.${propName}`;
+                recurseCheck(_Config, _elt[propName], propPath, _missingEnvVariables);
+            }
+        }
+    } else if (
+        typeof _elt === "string" &&
+        // If no value defined in configuration (no fallback found)
+        !_Config.has(_path) &&
+        // If no value defined in an environment variable
+        // eslint-disable-next-line node/no-process-env
+        !(_elt in process.env)
+    ) {
+        _missingEnvVariables.push(_elt);
+    }
+    return _missingEnvVariables;
+}
+
+/**
+ * Checks for the presence of environment variables.
+ *
+ * For each environment variables,
+ *
+ * 1. Check if it exists and use its value
+ * 2. Otherwise, fallback to default configuration for the value
+ * 3. Not exists, and no fallback, then add environment variable to missing environment variables array
+ *
+ * If at least one environment variable is missing, then raise an error with missing environment variables list.
+ *
+ * @param {object} _Config Config object.
+ * @param {string} _path Config dir path.
+ * @returns {void} Nothing.
+ * @throws {Error} Raises an error if at least one environment variable is missing.
+ */
+function checkEnvVariables(_Config, _path) {
+    // console.info("checkEnvVariables");
+
+    const customConfig = require(`${_path}/custom-environment-variables.js`);
+    // console.debug(`config: ${JSON.stringify(customConfig)}`);
+    const missingEnvVariables = recurseCheck(_Config, customConfig, "", []);
+    // Raises an error if at least one environment variable is missing
+    if (missingEnvVariables.length > 0) {
+        throw new Error(`Missing environment variable(s): ${missingEnvVariables.join(", ")}`);
+    }
+}
+
+module.exports = checkEnvVariables;

--- a/lib/check-environment-variables.js
+++ b/lib/check-environment-variables.js
@@ -51,7 +51,7 @@ function recurseCheck(_Config, _elt, _path, _missingEnvVariables) {
  * @throws {Error} Raises an error if at least one environment variable is missing.
  */
 function checkEnvVariables(_Config, _path) {
-    // console.info("checkEnvVariables");
+    console.info("INFO: Run checkEnvVariables...");
 
     const customConfig = require(`${_path}/custom-environment-variables.js`);
     // console.debug(`config: ${JSON.stringify(customConfig)}`);

--- a/lib/config.js
+++ b/lib/config.js
@@ -4,6 +4,7 @@
 // http://lorenwest.github.com/node-config
 
 // Dependencies
+const checkEnvVariables = require('./check-environment-variables');
 const DeferredConfig = require('../defer').DeferredConfig;
 const RawConfig = require('../raw').RawConfig;
 let Parser = require('../parser');
@@ -18,6 +19,7 @@ let NODE_ENV;
 let APP_INSTANCE;
 let CONFIG_SKIP_GITCRYPT;
 let NODE_ENV_VAR_NAME;
+let NODE_CONFIG_DIR;
 let NODE_CONFIG_PARSER;
 const env = {};
 const configSources = [];          // Configuration sources - array of {name, original, parsed}
@@ -573,6 +575,7 @@ util.loadFileConfigs = function(configDir, options) {
 
   let dir = configDir || util.initParam('NODE_CONFIG_DIR', Path.join( process.cwd(), 'config') );
   dir = _toAbsolutePath(dir);
+  NODE_CONFIG_DIR = dir;
 
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
   CONFIG_SKIP_GITCRYPT = util.initParam('CONFIG_SKIP_GITCRYPT');
@@ -1101,8 +1104,9 @@ util.substituteDeep = function (substitutionMap, variables) {
       }
       else if (util.isObject(value)) { // work on the subtree, giving it a clone of the pathTo
         if ('__name' in value && '__format' in value && typeof vars[value.__name] !== 'undefined' && vars[value.__name] !== '') {
+          let parsedValue;
           try {
-            const parsedValue = util.parseString(vars[value.__name], value.__format);
+            parsedValue = util.parseString(vars[value.__name], value.__format);
           } catch(err) {
             err.message = '__format parser error in ' + value.__name + ': ' + err.message;
             throw err;
@@ -1515,6 +1519,11 @@ const config = module.exports = new Config();
 // copy methods to util for backwards compatibility
 util.stripComments = Parser.stripComments;
 util.stripYamlComments = Parser.stripYamlComments;
+
+// Check custom-environment-variables.*
+if (process.env.NODE_CONFIG_CHECK_ENV_VARS === "true") {
+    checkEnvVariables(config, NODE_CONFIG_DIR);
+}
 
 // Produce warnings if the configuration is empty
 const showWarnings = !(util.initParam('SUPPRESS_NO_CONFIG_WARNING'));

--- a/test/22-check-environment-variables.js
+++ b/test/22-check-environment-variables.js
@@ -1,0 +1,87 @@
+var requireUncached = require('./_utils/requireUncached');
+
+// Dependencies
+var vows   = require('vows'),
+    assert = require('assert'),
+    Path   = require('path');
+
+function handleConfig() {
+    try {
+        // Change the configuration directory for testing
+        process.env.NODE_CONFIG_DIR = [`${__dirname}/22-config`].join(Path.delimiter);
+        const config = requireUncached(`${__dirname}/../lib/config`);
+        return {
+            isError: false,
+            config,
+            defaultConfig: config.util.parseFile(Path.join(`${__dirname}/22-config/default.js`)),
+        };
+    } catch (_err) {
+        return {
+            isError: true,
+            error: _err,
+        };
+    }
+}
+
+vows.describe('Testing check environment variables from custom environment variables')
+.addBatch({
+    'check environment variables,': {
+        'with environment variables set': {
+            topic: function () {
+                process.env.NODE_CONFIG_CHECK_ENV_VARS = "true";
+
+                // Scenario: With environment variables set, configuration will use environment variables values.
+                process.env.SERVICE_NAME = "service-config";
+                process.env.SERVICE_PORT = "8888";
+                process.env.SERVICE_CORS = "true";
+                process.env.REQUESTS_HEADERS = `{"Content-Type":"text/plain"}`;
+
+                return handleConfig();
+            },
+            'should use environment variables and not use fallbacks values from default config': function (topic) {
+                assert.strictEqual(topic.isError, false);
+                assert.strictEqual(topic.config.service.name, "service-config");
+                assert.strictEqual(topic.config.service.port, 8888);
+                assert.strictEqual(topic.config.service.cors, true);
+                assert.deepStrictEqual(topic.config.requests.headers, {"Content-Type":"text/plain"});
+            },
+        },
+        'with environment variables unset': {
+            topic: function () {
+                process.env.NODE_CONFIG_CHECK_ENV_VARS = "true";
+
+                // Scenario: With environment variables unset, configuration will try to use environment variables values or use fallbacks values from default configuration.
+                // Note: There is no fall-back for SERVICE_NAME (part of the next scenario)
+                process.env.SERVICE_NAME = "service-config";
+                Reflect.deleteProperty(process.env, "SERVICE_PORT");
+                Reflect.deleteProperty(process.env, "SERVICE_CORS");
+                Reflect.deleteProperty(process.env, "REQUESTS_HEADERS");
+
+                return handleConfig();
+            },
+            'should use fallbacks values from default config': function (topic) {
+                assert.strictEqual(topic.isError, false);
+                assert.strictEqual(topic.config.service.name, "service-config");
+                assert.strictEqual(topic.config.service.port, topic.defaultConfig.service.port);
+                assert.strictEqual(topic.config.service.cors, topic.defaultConfig.service.cors);
+                assert.deepStrictEqual(topic.config.requests.headers, topic.defaultConfig.requests.headers);
+            },
+        },
+        'with environment variable SERVICE_NAME unset and no fallback': {
+            topic: function () {
+                process.env.NODE_CONFIG_CHECK_ENV_VARS = "true";
+
+                // Scenario: If an environment variable is unset and there is no fallback
+                // Use fallbacks for other environment variables
+                Reflect.deleteProperty(process.env, "SERVICE_NAME");
+
+                return handleConfig();
+            },
+            'should throw an error that environment variable is missing': function (topic) {
+                assert.strictEqual(topic.isError, true);
+                assert.strictEqual(topic.error.stack.startsWith("Error: Missing environment variable(s): SERVICE_NAME"), true);
+            },
+        },
+    },
+})
+.export(module);

--- a/test/22-check-environment-variables.js
+++ b/test/22-check-environment-variables.js
@@ -82,6 +82,14 @@ vows.describe('Testing check environment variables from custom environment varia
                 assert.strictEqual(topic.error.stack.startsWith("Error: Missing environment variable(s): SERVICE_NAME"), true);
             },
         },
+        teardown: function () {
+            // Cleanup environment variables
+            Reflect.deleteProperty(process.env, "NODE_CONFIG_CHECK_ENV_VARS");
+            Reflect.deleteProperty(process.env, "SERVICE_NAME");
+            Reflect.deleteProperty(process.env, "SERVICE_PORT");
+            Reflect.deleteProperty(process.env, "SERVICE_CORS");
+            Reflect.deleteProperty(process.env, "REQUESTS_HEADERS");
+        }
     },
 })
 .export(module);

--- a/test/22-config/custom-environment-variables.js
+++ b/test/22-config/custom-environment-variables.js
@@ -1,0 +1,19 @@
+module.exports = {
+    service: {
+        name: "SERVICE_NAME",
+        port: {
+            __name: "SERVICE_PORT",
+            __format: "number",
+        },
+        cors: {
+            __name: "SERVICE_CORS",
+            __format: "boolean",
+        },
+    },
+    requests: {
+        headers: {
+            __name: "REQUESTS_HEADERS",
+            __format: "json",
+        },
+    },
+};

--- a/test/22-config/default.js
+++ b/test/22-config/default.js
@@ -1,0 +1,11 @@
+module.exports = {
+	service: {
+		port: 8080,
+		cors: false,
+	},
+	requests: {
+		headers: {
+			"Content-Type": "application/json",
+		},
+	},
+};


### PR DESCRIPTION
## Description

Check environment variables defined in `custom-environment-variables.*`

Enabled if `NODE_CONFIG_CHECK_ENV_VARS` is set to `true`.

For each defined environment variables,

1. Check if it exists and use its value
2. Otherwise, fallback to default configuration for the value
3. Not exists, and no fallback, then add environment variable to missing environment variables array

If at least one environment variable is missing, then raise an error with missing environment variables list.

Example of error:

`Error: Missing environment variable(s): SERVICE_NAME`

## History

After using `node-config` in multiple services in my company for multiple months, we quickly realised a missing feature with `custom-environment-variables.js`.

When we deploy our services to production and environment variables were missing, we were not aware at startup that a value could be missing.

So we have created this file named `check-environment-variables.js` to exit early.

In the first version, all defined environment variables in `custom-environment-variables.js` were mandatory.
An error was triggered if at least one environment variable was missing.

Then, we made an enhancement to have them not considered mandatory if we have a fallback value in `default.*` files.

Current workflow is described above and can be simplified like this:

`Check env var --> Fallback --> Add env var to missing array --> Raise error if missing array length > 0`

## Sharing

As we are now using it since a long time, I think it could be interesting to share it with everyone.

Moreover, in our case it could become a native feature.

And we won't have to keep and copy paste in all our services `check-environment-variables.js`