### PR TITLE
BunJS: Fix issue with trying to load file that does not exist.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -828,7 +828,7 @@ util.parseFile = function(fullFilename, options) {
     fileContent = fileContent.replace(/^\uFEFF/, '');
   }
   catch (e2) {
-    if (e2.code !== 'ENOENT') {
+    if (e2.code !== 'ENOENT' && e2.code !== 'EBADF') {
       throw new Error('Config file ' + fullFilename + ' cannot be read. Error code is: '+e2.code
                         +'. Error message is: '+e2.message);
     }


### PR DESCRIPTION
On startup config attempts to load various files, such as "runtime.json". When loading, BunJS returns a different error code than NodeJS for files that do not exist. This updates the check to not throw an exception for this error code.

Let me know if you need any additional information.