### PR TITLE
Fix GH-746 - Loading config files order with APP_INSTANCE

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -638,12 +638,15 @@ util.loadFileConfigs = function(configDir, options) {
   let resolutionIndex = 1;
   const extNames = Parser.getFilesOrder();
   baseNames.forEach(function(baseName) {
-    extNames.forEach(function(extName) {
-      allowedFiles[baseName + '.' + extName] = resolutionIndex++;
-      if (APP_INSTANCE) {
-        allowedFiles[baseName + '-' + APP_INSTANCE + '.' + extName] = resolutionIndex++;
-      }
-    });
+    const fileNames = [baseName];
+    if (APP_INSTANCE) {
+      fileNames.push(baseName + '-' + APP_INSTANCE);
+    }
+    fileNames.forEach(function(fileName) {
+      extNames.forEach(function(extName) {
+        allowedFiles[fileName + '.' + extName] = resolutionIndex++;
+      });
+    })
   });
 
   const locatedFiles = util.locateMatchingFiles(dir, allowedFiles);

--- a/test/22-config/default-instance.json
+++ b/test/22-config/default-instance.json
@@ -1,0 +1,4 @@
+{
+    "prop2": "prop2FromJsonInstance",
+    "prop3": "prop3FromJsonInstance"
+}

--- a/test/22-config/default-instance.yml
+++ b/test/22-config/default-instance.yml
@@ -1,0 +1,1 @@
+prop3: prop3FromYmlInstance

--- a/test/22-config/default.yml
+++ b/test/22-config/default.yml
@@ -1,0 +1,3 @@
+prop1: prop1FromDefault
+prop2: prop2FromDefault
+prop3: prop3FromDefault

--- a/test/22-files-order.js
+++ b/test/22-files-order.js
@@ -1,0 +1,38 @@
+const requireUncached = require("./_utils/requireUncached");
+
+// Dependencies
+const vows = require("vows");
+const assert = require("assert");
+
+/**
+ * <p>Unit tests for the node-config library.  To run type:</p>
+ * <pre>npm test</pre>
+ * <p>Or, in a project that uses node-config:</p>
+ * <pre>npm test config</pre>
+ *
+ * @class ConfigTest
+ */
+
+vows.describe("Test suite for node-config").addBatch({
+  "Library initialization": {
+    topic: function () {
+      // Change the configuration directory for testing
+      process.env.NODE_CONFIG_DIR = __dirname + "/22-config";
+
+      // Hard-code $NODE_ENV=test for testing
+      process.env.NODE_ENV = "test";
+
+      // Test for multi-instance applications
+      process.env.NODE_APP_INSTANCE = "instance";
+
+      CONFIG = requireUncached(__dirname + "/../lib/config");
+
+      return CONFIG;
+    },
+    "Config files have been loaded in right order": function (CONFIG) {
+      assert.equal(CONFIG.get("prop1"), "prop1FromDefault");
+      assert.equal(CONFIG.get("prop2"), "prop2FromJsonInstance");
+      assert.equal(CONFIG.get("prop3"), "prop3FromYmlInstance");
+    },
+  },
+}).export(module);


### PR DESCRIPTION
This will fix the loading order when having different file extensions and working with APP_INSTANCE as well.
Instead of doing a `forEach` on basenames and extensions, then adding the `APP_INSTANCE`, the filename using the `APP_INSTANCE` is defined before going through all extensions, so that it is loaded after all extensions without the APP_INSTANCE being defined.

Did a console.log (that I removed) for the `allowedFiles` object when running the added test to show the difference:
Before the fix:
![image](https://github.com/node-config/node-config/assets/6448789/95a6a804-f640-4788-b41b-b6fd5bc69e11)

After the fix:
![image](https://github.com/node-config/node-config/assets/6448789/b23de556-039f-47e0-a56f-160e538af2aa)
