### PR TITLE
Fix conversion of Uint8Array to object (#761)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -372,6 +372,12 @@ util.makeImmutable = function(object, property, value) {
   if (Buffer.isBuffer(object)) {
     return object;
   }
+
+  if (util.isTypedArray(object)) {
+    Object.preventExtensions(object);
+    return object;
+  }
+
   let properties = null;
 
   // Backwards compatibility mode where property/value can be specified
@@ -1014,6 +1020,18 @@ util.cloneDeep = function cloneDeep(parent, depth, circular, prototype) {
       child = Buffer.alloc(parent.length);
       parent.copy(child);
       return child;
+    } else if (util.isTypedArray(parent)) {
+      if (parent.slice) {
+        // Note that Buffer's slice() semantics return a view of the original buffer,
+        // but we've checked for Buffer already
+        child = parent.slice();
+      } else if (DataView && parent instanceof DataView) {
+        child = new DataView(parent.buffer.slice());
+      } else {
+        // Unknown kind of typed array - shouldn't happen
+        child = new Uint8Array(parent.buffer.slice());
+      }
+      return child;
     } else {
       if (typeof prototype === 'undefined') child = Object.create(Object.getPrototypeOf(parent));
       else child = Object.create(prototype);
@@ -1340,7 +1358,7 @@ util.extendDeep = function(mergeInto) {
 /**
  * Is the specified argument a regular javascript object?
  *
- * The argument is an object if it's a JS object, but not an array.
+ * The argument is an object if it's a JS object, but not an array or a typed array.
  *
  * @protected
  * @method isObject
@@ -1348,7 +1366,7 @@ util.extendDeep = function(mergeInto) {
  * @return {boolean} TRUE if the arg is an object, FALSE if not
  */
 util.isObject = function(obj) {
-  return (obj !== null) && (typeof obj === 'object') && !(Array.isArray(obj));
+  return (obj !== null) && (typeof obj === 'object') && !(Array.isArray(obj)) && !(util.isTypedArray(obj));
 };
 
 /**
@@ -1361,6 +1379,18 @@ util.isObject = function(obj) {
  */
 util.isPromise = function(obj) {
   return Object.prototype.toString.call(obj) === '[object Promise]';
+};
+
+/**
+ * Is the specified argument a TypedArray?
+ *
+ * @protected
+ * @method isTypedArray
+ * @param obj {*} An argument of any type.
+ * @return {boolean} TRUE if the arg is a TypedArray, FALSE if not
+ */
+util.isTypedArray = function(obj) {
+  return ArrayBuffer.isView(obj);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "coffeescript": "2.2.4",
     "cson": "^3.0.1",
     "hjson": "^1.2.0",
-    "js-yaml": "^3.2.2",
+    "js-yaml": "^4.1.0",
     "properties": "~1.2.1",
     "semver": "5.3.0",
     "toml": "^2.0.6",

--- a/test/22-binary.js
+++ b/test/22-binary.js
@@ -1,0 +1,23 @@
+var requireUncached = require('./_utils/requireUncached');
+require('../parser');
+
+'use strict';
+
+var vows = require('vows'),
+  assert = require('assert');
+
+vows.describe('Tests for parsing binary data')
+  .addBatch({
+    'Using the YAML parser - Uint8Array': {
+      topic: function() {
+        process.env.NODE_CONFIG_DIR = __dirname + '/22-binary';
+        return requireUncached(__dirname + '/../lib/config');
+      },
+      'reading !!binary returns a real Uint8Array': function(CONFIG) {
+        assert.deepStrictEqual(CONFIG.get('auth'), {
+					secret: new Uint8Array([0x10, 0x11, 0x12, 0x13, 0x14, 0x15])
+				});
+      },
+    }
+  })
+  .export(module);

--- a/test/22-binary/default.yaml
+++ b/test/22-binary/default.yaml
@@ -1,0 +1,2 @@
+auth:
+  secret: !!binary 'EBESExQV'


### PR DESCRIPTION
As said in #761, `node-config` handles `TypedArray` values (including `Uint8Array`) incorrectly, wrapping them in proxy objects that are not accepted by anything that expects a real `TypedArray` (e.g. `Buffer.from()`).

I hit this bug with `js-yaml` 4.x, which made a breaking change compared to `js-yaml` 3.x, returning `Uint8Array` for `!!binary` values rather than returning `Buffer` like 3.x did.

This PR:
* Makes `makeImmutable()` ignore `TypedArray` and `DataView` values (leaving them mutable, as there's no way to make them immutable)
* Makes `cloneDeep()` correctly clone `TypedArray` and `DataView` values
* Bumps the `js-yaml` dev dependency to the latest version 4.1.0, which hits the bug in `node-config`
* Adds a test for the bug fixed