### PR TITLE
Remove usage of deprecated utils to fix warnings in Node 22

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -7,7 +7,6 @@
 const DeferredConfig = require('../defer').DeferredConfig;
 const RawConfig = require('../raw').RawConfig;
 let Parser = require('../parser');
-const Utils = require('util');
 const Path = require('path');
 const FileSystem = require('fs');
 
@@ -1003,12 +1002,12 @@ util.cloneDeep = function cloneDeep(parent, depth, circular, prototype) {
       return parent;
     }
 
-    if (Utils.isArray(parent)) {
+    if (Array.isArray(parent)) {
       child = [];
-    } else if (Utils.isRegExp(parent)) {
+    } else if (parent instanceof RegExp) {
       child = new RegExp(parent.source, util.getRegExpFlags(parent));
       if (parent.lastIndex) child.lastIndex = parent.lastIndex;
-    } else if (Utils.isDate(parent)) {
+    } else if (parent instanceof Date) {
       child = new Date(parent.getTime());
     } else if (useBuffer && Buffer.isBuffer(parent)) {
       child = Buffer.alloc(parent.length);

--- a/parser.js
+++ b/parser.js
@@ -1,5 +1,4 @@
 // External libraries are lazy-loaded only if these file types exist.
-const util = require("util");
 
 // webpack can't solve dynamic module
 // @see https://github.com/node-config/node-config/issues/755
@@ -61,7 +60,7 @@ Parser.xmlParser = function(filename, content) {
 Parser.jsParser = function(filename, content) {
   var configObject = require(filename);
 
-  if (configObject.__esModule && util.isObject(configObject.default)) {
+  if (configObject.__esModule && isObject(configObject.default)) {
     return configObject.default
   }
   return configObject;
@@ -366,3 +365,7 @@ Parser.setFilesOrder = function(name, newIndex) {
   }
   return order;
 };
+
+function isObject(arg) {
+  return (arg !== null) && (typeof arg === 'object');
+}


### PR DESCRIPTION
Fixes the following warnings when run in Node@22

```
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:20281) [DEP0053] DeprecationWarning: The `util.isObject` API is deprecated. Please use `arg !== null && typeof arg === "object"` instead.
(node:20281) [DEP0044] DeprecationWarning: The `util.isArray` API is deprecated. Please use `Array.isArray()` instead.
(node:20281) [DEP0055] DeprecationWarning: The `util.isRegExp` API is deprecated. Please use `arg instanceof RegExp` instead.
(node:20281) [DEP0047] DeprecationWarning: The `util.isDate` API is deprecated.  Please use `arg instanceof Date` instead.