### PR TITLE
Check if runtimeJson exists before attempting to parse

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -577,9 +577,6 @@ util.loadFileConfigs = function(configDir, options) {
   APP_INSTANCE = util.initParam('NODE_APP_INSTANCE');
   CONFIG_SKIP_GITCRYPT = util.initParam('CONFIG_SKIP_GITCRYPT');
 
-  // This is for backward compatibility
-  const runtimeFilename = util.initParam('NODE_CONFIG_RUNTIME_JSON', Path.join(dir , 'runtime.json') );
-
   NODE_CONFIG_PARSER = util.initParam('NODE_CONFIG_PARSER');
   if (NODE_CONFIG_PARSER) {
     try {
@@ -704,7 +701,7 @@ util.loadFileConfigs = function(configDir, options) {
   util.extendDeep(config, customEnvVars);
 
   // Extend the original config with the contents of runtime.json (backwards compatibility)
-  const runtimeJson = util.parseFile(runtimeFilename) || {};
+  const runtimeJson = util.getRuntimeConfig(dir, "json");
   util.extendDeep(config, runtimeJson);
 
   util.resolveDeferredConfigs(config);
@@ -1152,6 +1149,20 @@ util.getCustomEnvVars = function (configDir, extNames) {
   });
   return result;
 };
+
+util.getRuntimeConfig = function (configDir) {
+  let result = {};
+  const locatedFiles = util.locateMatchingFiles(configDir, { 'runtime.json': 10 });
+  if (locatedFiles.length === 1) {
+    const configObj = util.parseFile(locatedFiles[0]);
+    if (configObj) {
+      result = configObj;
+    }
+  } else if (locatedFiles.length > 1) {
+    throw Error(`Found multiple files matching for runtime.json`);
+  }
+  return result;
+}
 
 /**
  * Return true if two objects have equal contents.

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -471,7 +471,7 @@ vows.describe('Test suite for node-config')
     },
     'Multiple config directories': {
       'Verify first directory loaded': function() {
-        assert.equal(CONFIG.get('Customers.dbName'), 'from_default_xml');
+        assert.equal(CONFIG.get('Customers.dbName'), 'override_from_runtime_json');
       },
       'Verify second directory loaded': function() {
         assert.equal(CONFIG.get('different.dir'), true);


### PR DESCRIPTION
I'm working on a project using this library that runs into `ENAMETOOLONG` on OSX due to the raw prepending of the entire config dir value. `fs.existsSync` simply returns false in this case instead of blowing up.

This closed issue mentions the same problem https://github.com/node-config/node-config/issues/614

In our case, we use configs separated by business domain as well as environments to keep things clear and specific, if there is another alternative solution that you would prefer, I would happily implement it.