### PR TITLE
Add ability to use custom var for ENV detect

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -545,9 +545,10 @@ util.loadFileConfigs = function(configDir, options) {
   // Initialize
   const t = this;
   const config = {};
+  const customNodeEnv = util.initParam('NODE_CONFIG_ENV_VAR_NAME') || 'NODE_CONFIG_ENV'
 
   // Specify variables that can be used to define the environment
-  const node_env_var_names = ['NODE_CONFIG_ENV', 'NODE_ENV'];
+  const node_env_var_names = [customNodeEnv, 'NODE_ENV'];
 
   // Loop through the variables to try and set environment
   for (const node_env_var_name of node_env_var_names) {

--- a/test/12-node_env-override.js
+++ b/test/12-node_env-override.js
@@ -91,6 +91,25 @@ vows.describe('Tests for NODE_*_ENV load order')
   }
 })
 .addBatch({
+  'Verify behavior of specified var in NODE_CONFIG_ENV_VAR_NAME overriding NODE_ENV': {
+    topic: function() {
+      process.env.NODE_CONFIG_ENV_VAR_NAME = 'STAND_ENV';
+      process.env.STAND_ENV = 'apollo';
+      process.env.NODE_ENV = 'mercury';
+
+      return requireUncached(__dirname + '/../lib/config');
+    },
+    'NODE_CONFIG_ENV value should be used': function(CONFIG) {
+      assert.equal(CONFIG.get('deploymentUsed'), 'node-config-env-provided');
+    },
+    'Revert process runtime changes': function() {
+      delete process.env.NODE_CONFIG_ENV_VAR_NAME;
+      delete process.env.STAND_ENV;
+      delete process.env.NODE_ENV;
+    }
+  }
+})
+.addBatch({
   'Library destructor': {
     'Revert process runtime changes': function() {
       delete process.env.NODE_CONFIG_DIR;


### PR DESCRIPTION
In our production projects, we need the ability to set our own env variable to determine the current environment.

NODE_ENV bad variant because some libraries can only work with two NODE_ENV values ​​(development and production), but we may have others
NODE_CONFIG_ENV - it seems to us wrong for defining the current environment

We can use our environment variable with NODE_CONFIG_ENV at the same time, but it also seems wrong.

It would be cool if they could pass the name of the variable that will contain the value for the environment