### PR TITLE
fix: add runs-on to pr ci tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,6 +12,7 @@ concurrency:
 
 jobs:
   Unit-Tests:
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "config",
-  "version": "3.3.11",
+  "version": "3.3.12",
   "main": "./lib/config.js",
   "description": "Configuration control for production node deployments",
   "author": "Loren West <open_source@lorenwest.com>",


### PR DESCRIPTION
I done did forgot to add `runs-on`, so the PR CI is currently invalid, and won't run.