### PR TITLE
Add nyc for code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 .project
 node_modules
 npm-debug.log
+
 .idea
+
+.nyc_output
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,9 @@
-node_modules
 test
 tools
 ISSUE_TEMPLATE.md
 .*
+
+.idea
+
+.nyc_output
+coverage

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cson": "^3.0.1",
     "hjson": "^1.2.0",
     "js-yaml": "^3.2.2",
+    "nyc": "^15.1.0",
     "properties": "~1.2.1",
     "semver": "5.3.0",
     "toml": "^2.0.6",
@@ -46,8 +47,19 @@
   "engines": {
     "node": ">= 10.0.0"
   },
+  "nyc": {
+    "include": [
+      "*.js",
+      "lib/**/*.js"
+    ],
+    "extension": [
+      ".js"
+    ],
+    "report-dir": "./coverage",
+    "reporter": "lcov"
+  },
   "scripts": {
-    "test": "vows test/*.js --spec",
-    "vows": "vows"
+    "test": "nyc vows test/*.js --spec",
+    "vows": "nyc vows"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node": ">= 10.0.0"
   },
   "scripts": {
-    "test": "./node_modules/vows/bin/vows test/*.js --spec",
-    "vows": "./node_modules/vows/bin/vows"
+    "test": "vows test/*.js --spec",
+    "vows": "vows"
   }
 }


### PR DESCRIPTION
With the prospect of adding additional maintainers, before other people start merging PRs it would be good to have a clearer picture of what we have and that includes code coverage data on the builds. 

nyc@15.1.0 is the most recent version of nyc that is compatible with node >= 10, and I would rather not open engines discussion at this time.