### PR TITLE
Replace arguments fiddling with spread operator.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -1303,11 +1303,9 @@ util.diffDeep = function(object1, object2, depth) {
  * @param depth {integer} An optional depth to prevent recursion.  Default: 20.
  * @return {object} The altered mergeInto object is returned
  */
-util.extendDeep = function(mergeInto) {
+util.extendDeep = function(mergeInto, ...vargs) {
 
   // Initialize
-  const t = this;
-  const vargs = Array.prototype.slice.call(arguments, 1);
   let depth = vargs.pop();
   if (typeof(depth) != 'number') {
     vargs.push(depth);


### PR DESCRIPTION
Since none of the code uses more than 3 arguments this doesn't really affect performance much (tested with tinybench) Using arguments deoptimizes JS code, but it's the only spot we're doing this, so it should go.

Spotted while looking at the traversal bug.