### PR TITLE
Fix over-recursion in async and deferred processing

### DIFF
--- a/async.js
+++ b/async.js
@@ -41,12 +41,11 @@ function resolveAsyncConfigs(config) {
   var promises = [];
   var resolvers = [];
   (function iterate(prop) {
-    var propsToSort = [];
-    for (var property in prop) {
-      if (Object.hasOwnProperty.call(prop, property) && prop[property] != null) {
-        propsToSort.push(property);
-      }
+    if (prop.constructor === String) {
+      return;
     }
+
+    var propsToSort = Object.keys(prop).filter((property) => prop[property] != null);
     propsToSort.sort().forEach(function(property) {
       if (prop[property].constructor === Object) {
         iterate(prop[property]);
@@ -54,7 +53,7 @@ function resolveAsyncConfigs(config) {
       else if (prop[property].constructor === Array) {
         prop[property].forEach(iterate);
       }
-      else if (prop[property] && prop[property].async === asyncSymbol) {
+      else if (prop[property].async === asyncSymbol) {
         resolvers.push(prop[property].prepare(config, prop, property));
         promises.push(prop[property]);
       }

--- a/lib/config.js
+++ b/lib/config.js
@@ -774,16 +774,12 @@ util.resolveDeferredConfigs = function (config) {
   const deferred = [];
 
   function _iterate (prop) {
+    if (prop.constructor === String) {
+      return;
+    }
 
     // We put the properties we are going to look it in an array to keep the order predictable
-    const propsToSort = [];
-
-    // First step is to put the properties of interest in an array
-    for (const property in prop) {
-      if (Object.hasOwnProperty.call(prop, property) && prop[property] != null) {
-        propsToSort.push(property);
-      }
-    }
+    const propsToSort = Object.keys(prop).filter((property) => prop[property] != null);
 
     // Second step is to iterate of the elements in a predictable (sorted) order
     propsToSort.sort().forEach(function (property) {


### PR DESCRIPTION
for-in will iterate on Strings.

Fixes #610

Adding a sanity check to avoid recursing on them, which should speed up both of these operations substantially.

Also swapping Object.keys() in since we end up filtering by hasOwnProperty() anyway.