### PR TITLE
Add support for jsonc file extension

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -519,11 +519,11 @@ util.getOption = function(options, optionName, defaultValue) {
  * </pre>
  *
  * <p>
- * EXT can be yml, yaml, coffee, iced, json, cson or js signifying the file type.
+ * EXT can be yml, yaml, coffee, iced, json, jsonc, cson or js signifying the file type.
  * yaml (and yml) is in YAML format, coffee is a coffee-script, iced is iced-coffee-script,
- * json is in JSON format, cson is in CSON format, properties is in .properties format
- * (http://en.wikipedia.org/wiki/.properties), and js is a javascript executable file that is
- * require()'d with module.exports being the config object.
+ * json is in JSON format, jsonc is in JSONC format, cson is in CSON format, properties is 
+ * in .properties format (http://en.wikipedia.org/wiki/.properties), and js is a javascript
+ * executable file that is require()'d with module.exports being the config object.
  * </p>
  *
  * <p>
@@ -806,7 +806,7 @@ util.resolveDeferredConfigs = function (config) {
  * .js = File to run that has a module.exports containing the config object
  * .coffee = File to run that has a module.exports with coffee-script containing the config object
  * .iced = File to run that has a module.exports with iced-coffee-script containing the config object
- * All other supported file types (yaml, toml, json, cson, hjson, json5, properties, xml)
+ * All other supported file types (yaml, toml, json, jsonc, cson, hjson, json5, properties, xml)
  * are parsed with util.parseString.
  *
  * If the file doesn't exist, a null will be returned.  If the file can't be
@@ -881,7 +881,8 @@ util.parseFile = function(fullFilename, options) {
  *
  * The format determines the parser to use.
  *
- * json = File is parsed using JSON.parse()
+ * json = Parsed with a JSON5 parser
+ * jsonc = Parsed with a JSON5 parser
  * yaml (or yml) = Parsed with a YAML parser
  * toml = Parsed with a TOML parser
  * cson = Parsed with a CSON parser

--- a/parser.js
+++ b/parser.js
@@ -247,7 +247,7 @@ Parser.numberParser = function(filename, content) {
   return Number.isNaN(numberValue) ? undefined : numberValue;
 };
 
-var order = ['js', 'cjs', 'mjs', 'ts', 'json', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml',
+var order = ['js', 'cjs', 'mjs', 'ts', 'json', 'jsonc', 'json5', 'hjson', 'toml', 'coffee', 'iced', 'yaml', 'yml', 'cson', 'properties', 'xml',
   'boolean', 'number'];
 var definitions = {
   cjs: Parser.jsParser,
@@ -257,6 +257,7 @@ var definitions = {
   iced: Parser.icedParser,
   js: Parser.jsParser,
   json: Parser.jsonParser,
+  jsonc: Parser.jsonParser,
   json5: Parser.json5Parser,
   mjs: Parser.jsParser,
   properties: Parser.propertiesParser,

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -76,6 +76,10 @@ vows.describe('Test suite for node-config')
       assert.equal(CONFIG.ContainsQuote, '"this has a quote"');
     },
 
+    'Loading configurations from a JSONC file is correct': function() {
+      assert.equal(CONFIG.AnotherModule.parm1jsonc, 'value1-jsonc');
+    },
+
     'Loading configurations from a .yaml YAML file is correct': function() {
       assert.equal(CONFIG.AnotherModule.parm2, 'value2');
     },

--- a/test/config/default.jsonc
+++ b/test/config/default.jsonc
@@ -1,0 +1,12 @@
+{
+
+  // Comment to test comment ignoring
+
+  "Customers": {
+    "dbName":"from_default_jsonc" // Line comment to test comment ignoring
+  },
+  "AnotherModule": {
+    "parm1jsonc":"value1-jsonc"
+  }
+  
+}


### PR DESCRIPTION
While **node-config** DO support comments in `.json` and `.json5` file extensions (it uses **json5** parser for both), it doesn't support the `.jsonc` file extension.

Why is this important? Comments are not allowed in the **JSON** specification, and even if they are supported by **node-config**, adding them to a `.json` file will trigger all sorts of errors in IDEs, linters, formatters, code analysis tools, and alike.

Using `.json5` file extension could be a solution, if you're willing to open the doors of your config files to a completely new and full of possibilities file format (**JSON5**). However, if you just want the good ol' **JSON** format, with comments, `.jsonc` is what you need

