### PR TITLE
Stop destructive updates to path in setPath

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -128,12 +128,12 @@ const util = Config.prototype.util = {};
  * Underlying get mechanism
  *
  * @private
- * @method getImpl
+ * @method getPath
  * @param object {object} - Object to get the property for
  * @param property {string|string[]} - The property name to get (as an array or '.' delimited string)
  * @return value {*} - Property value, including undefined if not defined.
  */
-const getImpl= function(object, property) {
+function getPath(object, property) {
   const t = this;
   const elems = Array.isArray(property) ? property : property.split('.');
   const name = elems[0];
@@ -145,8 +145,9 @@ const getImpl= function(object, property) {
   if (value === null || typeof value !== 'object') {
     return undefined;
   }
-  return getImpl(value, elems.slice(1));
-};
+
+  return getPath(value, elems.slice(1));
+}
 
 /**
  * <p>Get a configuration value</p>
@@ -174,7 +175,7 @@ Config.prototype.get = function(property) {
     checkMutability = false;
   }
   const t = this;
-  const value = getImpl(t, property);
+  const value = getPath(t, property);
 
   // Produce an exception if the property doesn't exist
   if (typeof value === "undefined") {
@@ -205,7 +206,7 @@ Config.prototype.has = function(property) {
     return false;
   }
   const t = this;
-  return typeof getImpl(t, property) !== "undefined";
+  return typeof getPath(t, property) !== "undefined";
 };
 
 /**
@@ -246,6 +247,7 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   // Copy the properties into a new object
   const t = this;
   const moduleConfig = util.cloneDeep(defaultProperties);
+  const path = moduleName.split('.');
 
   // Set module defaults into the first sources element
   if (configSources.length === 0 || configSources[0].name !== 'Module Defaults') {
@@ -254,17 +256,18 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
       parsed: {}
     });
   }
-  util.setPath(configSources[0].parsed, moduleName.split('.'), {});
-  util.extendDeep(getImpl(configSources[0].parsed, moduleName), defaultProperties);
+
+  util.setPath(configSources[0].parsed, path, {});
+  util.extendDeep(getPath(configSources[0].parsed, path), defaultProperties);
 
   // Create a top level config for this module if it doesn't exist
-  util.setPath(t, moduleName.split('.'), getImpl(t, moduleName) || {});
+  util.setPath(t, path, getPath(t, path) || {});
 
   // Extend local configurations into the module config
-  util.extendDeep(moduleConfig, getImpl(t, moduleName));
+  util.extendDeep(moduleConfig, getPath(t, path));
 
   // Merge the extended configs without replacing the original
-  util.extendDeep(getImpl(t, moduleName), moduleConfig);
+  util.extendDeep(getPath(t, path), moduleConfig);
 
   // reset the mutability check for "config.get" method.
   // we are not making t[moduleName] immutable immediately,
@@ -274,7 +277,7 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
   }
 
   // Attach handlers & watchers onto the module config object
-  return util.attachProtoDeep(getImpl(t, moduleName));
+  return util.attachProtoDeep(getPath(t, path));
 };
 
 /**
@@ -521,7 +524,7 @@ util.getOption = function(options, optionName, defaultValue) {
  * <p>
  * EXT can be yml, yaml, coffee, iced, json, jsonc, cson or js signifying the file type.
  * yaml (and yml) is in YAML format, coffee is a coffee-script, iced is iced-coffee-script,
- * json is in JSON format, jsonc is in JSONC format, cson is in CSON format, properties is 
+ * json is in JSON format, jsonc is in JSONC format, cson is in CSON format, properties is
  * in .properties format (http://en.wikipedia.org/wiki/.properties), and js is a javascript
  * executable file that is require()'d with module.exports being the config object.
  * </p>
@@ -1066,19 +1069,19 @@ util.cloneDeep = function cloneDeep(parent, depth, circular, prototype) {
  * @param value {*} - value to set, ignoring null
  */
 util.setPath = function (object, path, value) {
-  let nextKey = null;
   if (value === null || path.length === 0) {
     return;
   }
-  else if (path.length === 1) { // no more keys to make, so set the value
-    object[path.shift()] = value;
-  }
-  else {
-    nextKey = path.shift();
+
+  let nextKey = path[0];
+  if (path.length === 1) { // no more keys to make, so set the value
+    object[nextKey] = value;
+  } else {
     if (!Object.hasOwnProperty.call(object, nextKey)) {
       object[nextKey] = {};
     }
-    util.setPath(object[nextKey], path, value);
+
+    util.setPath(object[nextKey], path.slice(1), value);
   }
 };
 

--- a/test/5-getConfigSources.js
+++ b/test/5-getConfigSources.js
@@ -15,7 +15,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
       process.env.NODE_CONFIG = '{}';
       delete process.env.NODE_APP_INSTANCE;
       process.env.NODE_CONFIG_STRICT_MODE=0;
-      process.argv = ["node","path/to/some.js","--NODE_CONFIG='{}'"];
+      process.argv = ["node","path/to/some.js","--NODE_CONFIG='{}'"]; //TODO: This is a parse error so not testing the right thing
       var config = requireUncached(__dirname + '/../lib/config');
       return config.util.getConfigSources();
     },
@@ -45,7 +45,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
       return config.util.getConfigSources();
     },
 
-    'Two files should result in two entries': function(topic) {
+    'Three files should result in three entries': function(topic) {
         assert.equal(topic.length,3);
     },
 
@@ -69,7 +69,7 @@ vows.describe('Tests config.util.getConfigSources').addBatch({
       return config.util.getConfigSources();
     },
 
-    'Two files should result in two entries': function(topic) {
+    'Three files should result in three entries': function(topic) {
         assert.equal(topic.length,3);
     },
 


### PR DESCRIPTION
Simplify setModuleDefaults and getImpl/setPath to getPath/setPath

This is prep work for a bigger surgery to split config.js into two pieces.