### PR TITLE
Remove files from configSources that are not part of the config sources.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -501,13 +501,9 @@ util.loadFileConfigs = function(configDir, options) {
     let opts = {...FIRST_LOAD.options, configDir, ...options};
     newLoad = new LoadInfo(opts);
     _load(newLoad);
-
-    FIRST_LOAD.sourcesBug(newLoad.getSources());
   } else {
     newLoad = new LoadInfo({...FIRST_LOAD.options, ...options});
     _init(newLoad);
-
-    FIRST_LOAD.sourcesBug(newLoad.getSources());
   }
 
   return newLoad.config;
@@ -631,10 +627,6 @@ util.parseFile = function(fullFilename, options = {}) {
   let loadInfo = new LoadInfo(loadOpts);
 
   loadInfo.loadFile(fullFilename);
-
-  if (!options.skipConfigSources) {
-    FIRST_LOAD.sourcesBug(loadInfo.getSources());
-  }
 
   return loadInfo.config;
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -903,23 +903,6 @@ class LoadInfo {
   }
 
   /**
-   * Bug-preserving function
-   *
-   * This function conserves a bug in loadFileConfigs that makes additional loadFileConfigs
-   * calls show up as configSources on the singleton, which is incorrect and reduces the
-   * diagnostic value of inspecting the configSources after a program initialization.
-   *
-   * This needs to go but at present there is no other way to surface these values. So this
-   * function exists until a side-effect-free loadFileConfigs() can be created at the end
-   * of this rearchitecting work.
-   *
-   * @param sources
-   */
-  sourcesBug(sources) {
-    this.sources && this.sources.push(...sources);
-  }
-
-  /**
    * <p>
    * Set default configurations for a node.js module.
    * </p>

--- a/test/18-skipConfigSources.js
+++ b/test/18-skipConfigSources.js
@@ -27,13 +27,6 @@ vows.describe('Testing the skipConfigSources functionality')
             },
             'should not add the configuration object to the global configuration': function (topic){
                 assert(!topic.config.has('arbitraryKey'));
-            },
-            'should add the file information to the config.util.getConfigSources array': function(topic) {
-                var configSources = topic.config.util.getConfigSources();
-                var lastEntry = configSources[configSources.length - 1 ];
-                var fullFileName = Path.join(__dirname,'/18-extra-config/customFile.json');
-                assert.deepStrictEqual(lastEntry.name, fullFileName);
-                assert.deepStrictEqual(lastEntry.parsed, { arbitraryKey: 'arbitraryValue'});
             }
         },
         'given a file path and an options parameter,': {
@@ -56,13 +49,6 @@ vows.describe('Testing the skipConfigSources functionality')
                 },
                 'should not add the configuration object to the global configuration': function (topic){
                     assert(!topic.config.has('arbitraryKey'));
-                },
-                'should add the file information to the config.util.getConfigSources array': function(topic) {
-                    var configSources = topic.config.util.getConfigSources();
-                    var lastEntry = configSources[configSources.length - 1 ];
-                    var fullFileName = Path.join(__dirname,'/18-extra-config/customFile.json');
-                    assert.deepStrictEqual(lastEntry.name, fullFileName);
-                    assert.deepStrictEqual(lastEntry.parsed, { arbitraryKey: 'arbitraryValue'});
                 }
             },
             'when the skipConfigSources flag is set to true': {
@@ -84,7 +70,7 @@ vows.describe('Testing the skipConfigSources functionality')
                 },
                 'should not add the configuration object to the global configuration': function (topic){
                     assert(!topic.config.has('arbitraryKey'));
-                }, 
+                },
                 'should not add the file information to the config.util.getConfigSources array': function(topic) {
                     var configSources = topic.config.util.getConfigSources();
                     var fullFileName = Path.join(__dirname,'/18-extra-config/customFile.json');
@@ -113,13 +99,6 @@ vows.describe('Testing the skipConfigSources functionality')
             },
             'should not add the configuration object to the global configuration': function (topic){
                 assert.deepStrictEqual(topic.config.get('someKey'),'testValue');
-            },
-            'should add the file information to the config.util.getConfigSources array': function(topic) {
-                var configSources = topic.config.util.getConfigSources();
-                var lastEntry = configSources[configSources.length - 1 ];
-                var fullFileName = Path.join(__dirname,'/18-extra-config/default.json');
-                assert.deepStrictEqual(lastEntry.name, fullFileName);
-                assert.deepStrictEqual(lastEntry.parsed, { someKey: 'anotherTestValue'});
             }
         },
         'given a directory and an options parameter,': {
@@ -142,13 +121,6 @@ vows.describe('Testing the skipConfigSources functionality')
                 },
                 'should not add the configuration object to the global configuration': function (topic){
                     assert.deepStrictEqual(topic.config.get('someKey'),'testValue');
-                },
-                'should add the file information to the config.util.getConfigSources array': function(topic) {
-                    var configSources = topic.config.util.getConfigSources();
-                    var lastEntry = configSources[configSources.length - 1 ];
-                    var fullFileName = Path.join(__dirname,'/18-extra-config/default.json');
-                    assert.deepStrictEqual(lastEntry.name, fullFileName);
-                    assert.deepStrictEqual(lastEntry.parsed, { someKey: 'anotherTestValue'});
                 }
             },
             'when the skipConfigSources flag is set to true': {


### PR DESCRIPTION
parseFile adding any calls to the configSources causes the union of the configSources to not match Config.get()

fixes #806

I don't want to merge this for a big yet, to give time for any other 4.0 issues to be sorted before we start merging more breaking changes. But I wanted to clear this off of my mental todo list.