### PR TITLE
Simplify the merge logic in setModuleDefaults(), fix regression on trunk.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -4,7 +4,6 @@
 // http://lorenwest.github.com/node-config
 
 // Dependencies
-const DeferredConfig = require('../defer').DeferredConfig;
 const RawConfig = require('../raw').RawConfig;
 const { Util, LoadInfo } = require('./util.js');
 const Path = require('path');
@@ -211,14 +210,15 @@ util.setModuleDefaults = function (moduleName, defaultProperties) {
 
   // Copy the properties into a new object
   const t = this;
-  const moduleConfig = FIRST_LOAD.setModuleDefaults(moduleName, defaultProperties);
   const path = moduleName.split('.');
+  const moduleConfig = FIRST_LOAD.setModuleDefaults(moduleName, defaultProperties);
+  let existing = Util.getPath(t, path);
 
-  // Create a top level config for this module if it doesn't exist
-  Util.setPath(t, path, Util.getPath(t, path) || {});
-
-  // Merge the extended configs without replacing the original
-  Util.extendDeep(Util.getPath(t, path), moduleConfig);
+  if (existing === undefined) {
+    Util.setPath(t, path, Util.cloneDeep(moduleConfig));
+  } else {
+    Util.extendDeep(existing, moduleConfig);
+  }
 
   // reset the mutability check for "config.get" method.
   // we are not making t[moduleName] immutable immediately,

--- a/lib/util.js
+++ b/lib/util.js
@@ -949,7 +949,7 @@ class LoadInfo {
    * @method setModuleDefaults
    * @param moduleName {string} - Name of your module.
    * @param defaultProperties {Object} - The default module configuration.
-   * @return moduleConfig {Object} - The module level configuration object.
+   * @return {Object} - The module level configuration object.
    */
   setModuleDefaults(moduleName, defaultProperties) {
     const moduleConfig = Util.cloneDeep(defaultProperties);
@@ -964,18 +964,10 @@ class LoadInfo {
     }
 
     const path = moduleName.split('.');
+    Util.setPath(moduleDefaults, path, Util.cloneDeep(defaultProperties)); // TODO: This clobber is from the original code, and is a bug
 
-    Util.setPath(moduleDefaults, path, {});
-    Util.extendDeep(Util.getPath(moduleDefaults, path), defaultProperties);
-
-    // Create a top level config for this module if it doesn't exist
-    Util.setPath(this.config, path, Util.getPath(this.config, path) || {});
-
-    // Extend local configurations into the module config
-    Util.extendDeep(moduleConfig, Util.getPath(this.config, path));
-
-    // Merge the extended configs without replacing the original
-    Util.extendDeep(Util.getPath(this.config, path), moduleConfig);
+    Util.extendDeep(moduleConfig, Util.getPath(this.config, path) || {});
+    Util.setPath(this.config, path, moduleConfig);
 
     return moduleConfig;
   }

--- a/lib/util.js
+++ b/lib/util.js
@@ -965,7 +965,7 @@ class LoadInfo {
 
     const path = moduleName.split('.');
 
-    Util.setPath(moduleDefaults, moduleName.split('.'), {});
+    Util.setPath(moduleDefaults, path, {});
     Util.extendDeep(Util.getPath(moduleDefaults, path), defaultProperties);
 
     // Create a top level config for this module if it doesn't exist

--- a/test/2-config-test.js
+++ b/test/2-config-test.js
@@ -418,6 +418,25 @@ vows.describe('Test suite for node-config')
       assert.equal(moduleConfig.parm2, 2000);
     },
 
+    'Config.get() before setModuleDefaults() can see updates': function() {
+      process.env.ALLOW_CONFIG_MUTATIONS = true;
+
+      const mutableConfig = requireUncached(__dirname + '/../lib/config');
+
+      let defaults = {
+        someValue: "default"
+      };
+
+      try {
+        let customers = mutableConfig.get('Customers');
+
+        mutableConfig.util.setModuleDefaults('Customers', defaults);
+
+        assert.equal(customers.get("someValue"), "default");
+      } finally {
+        delete process.env.ALLOW_CONFIG_MUTATIONS;
+      }
+    },
     'Prototypes are applied by setModuleDefaults even if no previous config exists for the module': function() {
       var BKTestModuleDefaults = {
         parm1: 1000, parm2: 2000, parm3: 3000,


### PR DESCRIPTION
This code always did more work than it needed to but during the config.js/util.js split it sprouted a couple more defensive copies.

The existing code has some unnecessary tree merge logic in util.js, which makes the code difficult to follow. This change simplifies that code.

Within Config.util however, that 'unnecessary' logic does create one feature which my previous PR did not cover: Calling Config.get() prior to calling `setModuleDefaults` in 4.0 and earlier resulted in the Config object still being able to see the new defaults. That can only happen when allow_config_mutations is true, but this PR conserves that behavior when it is necessary.
