### PR TITLE
Resolve setModuleDefaults in chronological order

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -460,6 +460,7 @@ class Util {
    * @param object {Object} - Object to set the property on
    * @param property {string|string[]} - The property name to get (as an array or '.' delimited string)
    * @param value {*} - value to set, ignoring null
+   * @return {*} - the given value
    */
   static setPath(object, property, value) {
     const path = Array.isArray(property) ? property : property.split('.');
@@ -481,6 +482,8 @@ class Util {
         next = next[name] = {};
       }
     }
+
+    return value;
   }
 
   /**
@@ -967,9 +970,8 @@ class LoadInfo {
     Util.setPath(moduleDefaults, path, Util.cloneDeep(defaultProperties)); // TODO: This clobber is from the original code, and is a bug
 
     Util.extendDeep(moduleConfig, Util.getPath(this.config, path) || {});
-    Util.setPath(this.config, path, moduleConfig);
 
-    return moduleConfig;
+    return Util.setPath(this.config, path, moduleConfig);
   }
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -750,11 +750,13 @@ class LoadInfo {
    * @param options {LoadOptions=} - defaults to reading from environment variables
    */
   constructor(options, env = new Env()) {
-    this.config = {};
     this.env = env;
     this.options = { ...DEFAULT_OPTIONS, ...options };
     this.sources = this.options.skipConfigSources ? undefined : [];
     this.parser = this.options.parser;
+    this.config = {};
+    this.defaults = undefined;
+    this.unmerged = undefined;
   }
 
   /**
@@ -955,21 +957,22 @@ class LoadInfo {
    * @return {Object} - The module level configuration object.
    */
   setModuleDefaults(moduleName, defaultProperties) {
-    const moduleConfig = Util.cloneDeep(defaultProperties);
-    let moduleDefaults;
-
-    if (this.sources.length > 0 && this.sources[0].name === 'Module Defaults') {
-      moduleDefaults = this.sources[0].parsed;
-    } else {
-      let source = { name: 'Module Defaults', parsed: {} };
-      this.sources.splice(0, 0, source);
-      moduleDefaults = source.parsed;
+    if (this.defaults === undefined) {
+      this.defaults = {};
+      this.unmerged = {};
+      this.sources.splice(0, 0, { name: 'Module Defaults', parsed: this.defaults });
     }
 
     const path = moduleName.split('.');
-    Util.setPath(moduleDefaults, path, Util.cloneDeep(defaultProperties)); // TODO: This clobber is from the original code, and is a bug
+    const defaults = Util.setPath(this.defaults, path, Util.getPath(this.defaults, path) ?? {});
 
-    Util.extendDeep(moduleConfig, Util.getPath(this.config, path) || {});
+    Util.extendDeep(defaults, defaultProperties);
+
+    const original =
+        Util.getPath(this.unmerged, path) ??
+        Util.setPath(this.unmerged, path, Util.getPath(this.config, path) ?? {});
+
+    const moduleConfig = Util.extendDeep({}, defaults, original);
 
     return Util.setPath(this.config, path, moduleConfig);
   }

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -404,6 +404,10 @@ vows.describe('Tests for util functions')
         util.setPath(topic, 'EnvOverride.oauth.secret', 'ANOTHER');
         assert.equal(topic.EnvOverride.oauth.secret, 'ANOTHER');
       },
+      'returns the given value': function (topic) {
+        let input = { foo: "3"};
+        assert.equal(util.setPath(topic, 'some.path', input), input);
+      }
     },
   })
   .addBatch({

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -500,10 +500,10 @@ vows.describe('Tests for util functions')
         assert.deepEqual(loadInfo.config, { foo: { field1: 'set', field2: 'another' } });
       },
       'can be called multiple times for the same key': function (loadInfo) {
-        loadInfo.setModuleDefaults("foo", { field2: 'another'});
-        loadInfo.setModuleDefaults("foo", { field3: 'additional'});
+        loadInfo.setModuleDefaults("foo", { field2: 'another', field3: 'one'});
+        loadInfo.setModuleDefaults("foo", { field3: 'two'});
 
-        assert.deepEqual(loadInfo.config, { foo: { field1: 'set', field2: 'another', field3: 'additional' } });
+        assert.deepEqual(loadInfo.config, { foo: { field1: 'set', field2: 'another', field3: 'two' } });
       },
       'tracks the sources': function () {
         let loadInfo = new LoadInfo({});


### PR DESCRIPTION
If setModuleDefaults is called multiple times with overlapping values, make sure that they are accumulated in the correct order.

Fixes bug #825 