### PR TITLE
Extract more of Config.util to util.js

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -500,7 +500,7 @@ util.loadFileConfigs = function(configDir, options) {
   if (configDir) {
     let opts = {...FIRST_LOAD.options, configDir, ...options};
     newLoad = new LoadInfo(opts);
-    _load(newLoad);
+    newLoad.load();
 
     FIRST_LOAD.sourcesBug(newLoad.getSources());
   } else {
@@ -511,27 +511,6 @@ util.loadFileConfigs = function(configDir, options) {
   }
 
   return newLoad.config;
-}
-
-/**
- * scan and load config files into the given loadInfo
- *
- * @param loadInfo {LoadInfo}
- * @param additional {{name, value}[]} additional values to populate (usually from NODE_CONFIG
- * @private
- */
-function _load(loadInfo, additional) {
-  Util.loadFileConfigs(loadInfo);
-
-  if (additional) {
-    for (let {name, config} of additional) {
-      loadInfo.addConfig(name, config);
-    }
-  }
-  // Override with environment variables if there is a custom-environment-variables.EXT mapping file
-  _loadCustomEnvVars(loadInfo);
-
-  util.resolveDeferredConfigs(loadInfo.config);
 }
 
 /**
@@ -575,7 +554,7 @@ function _init(loadInfo) {
   // Place the mixed NODE_CONFIG into the environment
   loadInfo.setEnv('NODE_CONFIG', JSON.stringify(Util.extendDeep(envConfig, cmdLineConfig, {})));
 
-  _load(loadInfo, additional);
+  loadInfo.load(additional);
 }
 
 /**
@@ -594,6 +573,10 @@ util.locateMatchingFiles = function(configDirs, allowedFiles) {
   return Util.locateMatchingFiles(configDirs, allowedFiles);
 };
 
+/**
+ * @deprecated use Util.resolveDeferredConfigs
+ * @param config
+ */
 // Using basic recursion pattern, find all the deferred values and resolve them.
 util.resolveDeferredConfigs = function (config) {
   return Util.resolveDeferredConfigs(config);
@@ -660,16 +643,14 @@ util.parseFile = function(fullFilename, options = {}) {
  * after synchronous module loading.
  *
  * @protected
+ * @deprecated
  * @method parseString
  * @param content {string} The full content
  * @param format {string} The format to be parsed
  * @return {configObject} The configuration object parsed from the string
  */
 util.parseString = function (content, format) {
-  const parser = FIRST_LOAD.parser.getParser(format);
-  if (typeof parser === 'function') {
-    return parser(null, content);
-  }
+  return FIRST_LOAD.parseString(content, format);
 };
 
 /**
@@ -761,6 +742,8 @@ util.setPath = function (object, path, value) {
  * 3. And parent keys are created as necessary to retain the structure of substitutionMap.
  *
  * @protected
+ * @deprecated
+ *
  * @method substituteDeep
  * @param substitutionMap {Object} - an object whose terminal (non-subobject) values are strings
  * @param variables {object[string:value]} - usually process.env, a flat object used to transform
@@ -769,40 +752,7 @@ util.setPath = function (object, path, value) {
  *      corresponded to a key in `variables`
  */
 util.substituteDeep = function (substitutionMap, variables) {
-  const result = {};
-
-  function _substituteVars(map, vars, pathTo) {
-    for (const prop in map) {
-      const value = map[prop];
-      if (typeof(value) === 'string') { // We found a leaf variable name
-        if (typeof vars[value] !== 'undefined' && vars[value] !== '') { // if the vars provide a value set the value in the result map
-          Util.setPath(result, pathTo.concat(prop), vars[value]);
-        }
-      }
-      else if (Util.isObject(value)) { // work on the subtree, giving it a clone of the pathTo
-        if ('__name' in value && '__format' in value && typeof vars[value.__name] !== 'undefined' && vars[value.__name] !== '') {
-          let parsedValue;
-          try {
-            parsedValue = util.parseString(vars[value.__name], value.__format);
-          } catch(err) {
-            err.message = '__format parser error in ' + value.__name + ': ' + err.message;
-            throw err;
-          }
-          Util.setPath(result, pathTo.concat(prop), parsedValue);
-        } else {
-          _substituteVars(value, vars, pathTo.concat(prop));
-        }
-      }
-      else {
-        let msg = "Illegal key type for substitution map at " + pathTo.join('.') + ': ' + typeof(value);
-        throw Error(msg);
-      }
-    }
-  }
-
-  _substituteVars(substitutionMap, variables, []);
-  return result;
-
+  return FIRST_LOAD.substituteDeep(substitutionMap, variables);
 };
 
 /**
@@ -820,34 +770,10 @@ util.getCustomEnvVars = function (configDir, extNames) {
   let options = {...FIRST_LOAD.options, configDir};
   let loadInfo = new LoadInfo(options);
 
-  _loadCustomEnvVars(loadInfo, extNames);
+  loadInfo.loadCustomEnvVars(extNames);
 
   return loadInfo.config;
 };
-
-/**
- *
- * @param loadInfo {LoadInfo}
- * @param extNames {string[]=} extensions
- * @returns {{}}
- * @private
- */
-function _loadCustomEnvVars(loadInfo, extNames) {
-  let resolutionIndex = 1;
-  const allowedFiles = {};
-  const options = loadInfo.options;
-
-  extNames = extNames ?? loadInfo.parser.getFilesOrder();
-
-  extNames.forEach(function (extName) {
-    allowedFiles['custom-environment-variables' + '.' + extName] = resolutionIndex++;
-  });
-
-  const locatedFiles = Util.locateMatchingFiles(options.configDir, allowedFiles);
-  locatedFiles.forEach(function (fullFilename) {
-    loadInfo.loadFile(fullFilename, (configObj) => util.substituteDeep(configObj, process.env));
-  });
-}
 
 /**
  * Return true if two objects have equal contents.

--- a/lib/config.js
+++ b/lib/config.js
@@ -5,7 +5,7 @@
 
 // Dependencies
 const RawConfig = require('../raw').RawConfig;
-const { Util, LoadInfo } = require('./util.js');
+const { Util, Load } = require('./util.js');
 const Path = require('path');
 
 const DEFAULT_CLONE_DEPTH = 20;
@@ -499,12 +499,12 @@ util.loadFileConfigs = function(configDir, options) {
 
   if (configDir) {
     let opts = {...FIRST_LOAD.options, configDir, ...options};
-    newLoad = new LoadInfo(opts);
-    newLoad.load();
+    newLoad = new Load(opts);
+    newLoad.scan();
 
     FIRST_LOAD.sourcesBug(newLoad.getSources());
   } else {
-    newLoad = new LoadInfo({...FIRST_LOAD.options, ...options});
+    newLoad = new Load({...FIRST_LOAD.options, ...options});
     _init(newLoad);
 
     FIRST_LOAD.sourcesBug(newLoad.getSources());
@@ -517,17 +517,17 @@ util.loadFileConfigs = function(configDir, options) {
  * Scan with the default config dir (usually only at startup.
  * This adds a bit more data from NODE_CONFIG that _load() skips
  *
- * @param loadInfo {LoadInfo}
+ * @param load {Load}
  * @private
  */
-function _init(loadInfo) {
-  let options = loadInfo.options;
+function _init(load) {
+  let options = load.options;
   let additional = [];
 
   // Override configurations from the $NODE_CONFIG environment variable
   let envConfig = {};
 
-  loadInfo.setEnv("CONFIG_DIR", options.configDir);
+  load.setEnv("CONFIG_DIR", options.configDir);
 
   if (process.env.NODE_CONFIG) {
     try {
@@ -540,7 +540,7 @@ function _init(loadInfo) {
   }
 
   // Override configurations from the --NODE_CONFIG command line
-  let cmdLineConfig = loadInfo.getCmdLineArg('NODE_CONFIG');
+  let cmdLineConfig = load.getCmdLineArg('NODE_CONFIG');
   if (cmdLineConfig) {
     try {
       cmdLineConfig = JSON.parse(cmdLineConfig);
@@ -552,9 +552,9 @@ function _init(loadInfo) {
   }
 
   // Place the mixed NODE_CONFIG into the environment
-  loadInfo.setEnv('NODE_CONFIG', JSON.stringify(Util.extendDeep(envConfig, cmdLineConfig, {})));
+  load.setEnv('NODE_CONFIG', JSON.stringify(Util.extendDeep(envConfig, cmdLineConfig, {})));
 
-  loadInfo.load(additional);
+  load.scan(additional);
 }
 
 /**
@@ -611,7 +611,7 @@ util.resolveDeferredConfigs = function (config) {
  */
 util.parseFile = function(fullFilename, options = {}) {
   let loadOpts = {...FIRST_LOAD.options}; //TODO: Support full LoadOptions?
-  let loadInfo = new LoadInfo(loadOpts);
+  let loadInfo = new Load(loadOpts);
 
   loadInfo.loadFile(fullFilename);
 
@@ -768,11 +768,11 @@ util.substituteDeep = function (substitutionMap, variables) {
  */
 util.getCustomEnvVars = function (configDir, extNames) {
   let options = {...FIRST_LOAD.options, configDir};
-  let loadInfo = new LoadInfo(options);
+  let load = new Load(options);
 
-  loadInfo.loadCustomEnvVars(extNames);
+  load.loadCustomEnvVars(extNames);
 
-  return loadInfo.config;
+  return load.config;
 };
 
 /**
@@ -1027,7 +1027,8 @@ util.runStrictnessChecks = function (config) {
   }
 };
 
-const FIRST_LOAD = LoadInfo.fromEnvironment();
+/** @type {Load} */
+const FIRST_LOAD = Load.fromEnvironment();
 
 // Instantiate and export the configuration
 const config = module.exports = new Config();

--- a/lib/util.js
+++ b/lib/util.js
@@ -187,19 +187,19 @@ class Util {
    * </p>
    *
    * @method loadFileConfigs
-   * @param opts {LoadOptions | LoadInfo} parsing options or LoadInfo to update
+   * @param opts {LoadOptions | Load} parsing options or Load to update
    * @return loadConfig {LoadConfig}
    */
   static loadFileConfigs(opts) {
-    let loadInfo;
+    let load;
 
-    if (opts instanceof LoadInfo) {
-      loadInfo = opts;
+    if (opts instanceof Load) {
+      load = opts;
     } else {
-      loadInfo = new LoadInfo(opts);
+      load = new Load(opts);
     }
 
-    let options = loadInfo.options;
+    let options = load.options;
     let dir = options.configDir;
     dir = _toAbsolutePath(dir);
 
@@ -245,10 +245,10 @@ class Util {
 
     const locatedFiles = this.locateMatchingFiles(dir, allowedFiles);
     for (let fullFilename of locatedFiles) {
-      loadInfo.loadFile(fullFilename);
+      load.loadFile(fullFilename);
     }
 
-    return loadInfo;
+    return load;
   }
 
   /**
@@ -744,31 +744,28 @@ class Env {
  * @example
  * //load module defaults
  * const config = require("config");
- * const LoadInfo = require("config/util.js").LoadInfo;
+ * const Load = require("config/util.js").Load;
  *
- * let loadInfo = new LoadInfo({
- *    nodeEnv: process.env.NODE_CONFIG_ENV,
- *    configDir: Path.join(__dirname, "config")
- * });
+ * let load = Load.fromEnvironment();
  *
- * loadInfo.load();
+ * load.scan();
  *
- * config.setModuleDefaults("my-module", loadInfo.config);
+ * config.setModuleDefaults("my-module", load.config);
  *
  * @example
  * // verify configs
- * const LoadInfo = require("config/util.js").LoadInfo;
+ * const Load = require("config/util.js").Load;
  *
  * for (let environment of ["sandbox", "qa", "qa-hyderabad", "perf", "staging", "prod-east-1", "prod-west-2"] {
- *   let loadInfo = LoadInfo.fromEnvironment(environment);
+ *   let load = Load.fromEnvironment(environment);
  *
- *   loadInfo.load();
+ *   load.scan();
  * }
  *
  *
  * @class Load
  */
-class LoadInfo {
+class Load {
   /**
    * @constructor
    * @param options {LoadOptions=} - defaults to reading from environment variables
@@ -872,10 +869,10 @@ class LoadInfo {
   /**
    * scan and load config files in the same manner that config.js does
    *
-   * @param loadInfo {LoadInfo}
+   * @param load {Load}
    * @param additional {{name, value}[]=} additional values to populate (usually from NODE_CONFIG
    */
-  load(additional) {
+  scan(additional) {
     Util.loadFileConfigs(this);
 
     if (additional) {
@@ -1005,7 +1002,7 @@ class LoadInfo {
    *
    * <p>Using the function within your module:</p>
    * <pre>
-   *   loadInfo.setModuleDefaults("MyModule", {
+   *   load.setModuleDefaults("MyModule", {
    *   &nbsp;&nbsp;templateName: "t-50",
    *   &nbsp;&nbsp;colorScheme: "green"
    *   });
@@ -1141,7 +1138,7 @@ class LoadInfo {
    * in the config.js file
    * @param environments {string} the NODE_CONFIG_ENVs you want to load
    * @private
-   * @returns {LoadInfo}
+   * @returns {Load}
    */
   static fromEnvironment(environments) {
     let env = new Env();
@@ -1200,7 +1197,7 @@ class LoadInfo {
       gitCrypt
     };
 
-    return new LoadInfo(options, env);
+    return new Load(options, env);
   }
 }
 
@@ -1229,4 +1226,4 @@ function _loadParser(name, dir) {
   }
 }
 
-module.exports = { Util, LoadInfo };
+module.exports = { Util, Load: Load };

--- a/lib/util.js
+++ b/lib/util.js
@@ -308,8 +308,7 @@ class Util {
           for (let i = 0; i < prop[property].length; i++) {
             if (prop[property][i] instanceof DeferredConfig) {
               deferred.push(prop[property][i].prepare(config, prop[property], i));
-            }
-            else {
+            } else {
               _iterate(prop[property][i]);
             }
           }
@@ -737,7 +736,35 @@ class Env {
 
 
 /**
- * Data about a load operation
+ * The work horse of loading Config data - without the singleton.
+ *
+ * This class can be used to execute important workflows, such as build-time validations
+ * and Module Defaults.
+ *
+ * @example
+ * //load module defaults
+ * const config = require("config");
+ * const LoadInfo = require("config/util.js").LoadInfo;
+ *
+ * let loadInfo = new LoadInfo({
+ *    nodeEnv: process.env.NODE_CONFIG_ENV,
+ *    configDir: Path.join(__dirname, "config")
+ * });
+ *
+ * loadInfo.load();
+ *
+ * config.setModuleDefaults("my-module", loadInfo.config);
+ *
+ * @example
+ * // verify configs
+ * const LoadInfo = require("config/util.js").LoadInfo;
+ *
+ * for (let environment of ["sandbox", "qa", "qa-hyderabad", "perf", "staging", "prod-east-1", "prod-west-2"] {
+ *   let loadInfo = LoadInfo.fromEnvironment(environment);
+ *
+ *   loadInfo.load();
+ * }
+ *
  *
  * @class Load
  */
@@ -841,6 +868,28 @@ class LoadInfo {
     return this;
   }
 
+
+  /**
+   * scan and load config files in the same manner that config.js does
+   *
+   * @param loadInfo {LoadInfo}
+   * @param additional {{name, value}[]=} additional values to populate (usually from NODE_CONFIG
+   */
+  load(additional) {
+    Util.loadFileConfigs(this);
+
+    if (additional) {
+      for (let {name, config} of additional) {
+        this.addConfig(name, config);
+      }
+    }
+
+    // Override with environment variables if there is a custom-environment-variables.EXT mapping file
+    this.loadCustomEnvVars();
+
+    Util.resolveDeferredConfigs(this.config);
+  }
+
   /**
    * Load a file and add it to the configuration
    *
@@ -892,6 +941,28 @@ class LoadInfo {
     }
 
     this.addConfig(fullFilename, configObject, fileContent);
+  }
+
+  /**
+   * load custom-environment-variables
+   *
+   * @param extNames {string[]=} extensions
+   * @returns {{}}
+   */
+  loadCustomEnvVars(extNames) {
+    let resolutionIndex = 1;
+    const allowedFiles = {};
+
+    extNames = extNames ?? this.parser.getFilesOrder();
+
+    extNames.forEach(function (extName) {
+      allowedFiles['custom-environment-variables' + '.' + extName] = resolutionIndex++;
+    });
+
+    const locatedFiles = Util.locateMatchingFiles(this.options.configDir, allowedFiles);
+    locatedFiles.forEach((fullFilename) => {
+      this.loadFile(fullFilename, (configObj) => this.substituteDeep(configObj, process.env));
+    });
   }
 
   /**
@@ -973,34 +1044,126 @@ class LoadInfo {
   }
 
   /**
+   * Parse and return the specified string with the specified format.
+   *
+   * The format determines the parser to use.
+   *
+   * json = File is parsed using JSON.parse()
+   * yaml (or yml) = Parsed with a YAML parser
+   * toml = Parsed with a TOML parser
+   * cson = Parsed with a CSON parser
+   * hjson = Parsed with a HJSON parser
+   * json5 = Parsed with a JSON5 parser
+   * properties = Parsed with the 'properties' node package
+   * xml = Parsed with a XML parser
+   *
+   * If the file doesn't exist, a null will be returned.  If the file can't be
+   * parsed, an exception will be thrown.
+   *
+   * This method performs synchronous file operations, and should not be called
+   * after synchronous module loading.
+   *
+   * @protected
+   * @method parseString
+   * @param content {string} The full content
+   * @param format {string} The format to be parsed
+   * @return {configObject} The configuration object parsed from the string
+   */
+  parseString = function (content, format) {
+    const parser = this.parser.getParser(format);
+
+    if (typeof parser === 'function') {
+      return parser(null, content);
+    } else {
+      //TODO: throw on missing #753
+    }
+  }
+
+  /**
+   * Create a new object patterned after substitutionMap, where:
+   * 1. Terminal string values in substitutionMap are used as keys
+   * 2. To look up values in a key-value store, variables
+   * 3. And parent keys are created as necessary to retain the structure of substitutionMap.
+   *
+   * @protected
+   * @method substituteDeep
+   * @param substitutionMap {Object} - an object whose terminal (non-subobject) values are strings
+   * @param variables {object[string:value]} - usually process.env, a flat object used to transform
+   *      terminal values in a copy of substitutionMap.
+   * @returns {Object} - deep copy of substitutionMap with only those paths whose terminal values
+   *      corresponded to a key in `variables`
+   */
+  substituteDeep(substitutionMap, variables) {
+    const result = {};
+
+    const _substituteVars = (map, vars, pathTo) => {
+      for (const prop in map) {
+        const value = map[prop];
+
+        if (typeof(value) === 'string') { // We found a leaf variable name
+          if (typeof vars[value] !== 'undefined' && vars[value] !== '') { // if the vars provide a value set the value in the result map
+            Util.setPath(result, pathTo.concat(prop), vars[value]);
+          }
+        } else if (Util.isObject(value)) { // work on the subtree, giving it a clone of the pathTo
+          if ('__name' in value && '__format' in value && typeof vars[value.__name] !== 'undefined' && vars[value.__name] !== '') {
+            let parsedValue;
+            try {
+              parsedValue = this.parseString(vars[value.__name], value.__format);
+            } catch(err) {
+              err.message = '__format parser error in ' + value.__name + ': ' + err.message;
+              throw err;
+            }
+            Util.setPath(result, pathTo.concat(prop), parsedValue);
+          } else {
+            _substituteVars(value, vars, pathTo.concat(prop));
+          }
+        } else {
+          let msg = "Illegal key type for substitution map at " + pathTo.join('.') + ': ' + typeof(value);
+          throw Error(msg);
+        }
+      }
+    };
+
+    _substituteVars(substitutionMap, variables, []);
+    return result;
+  }
+
+  /**
    * Populate a LoadConfig entirely from environment variables.
    *
    * This is the way a base config is normally accomplished, but not for independent loads.
    *
    * This function exists in part to reduce the circular dependency of variable initializations
    * in the config.js file
+   * @param environments {string} the NODE_CONFIG_ENVs you want to load
    * @private
    * @returns {LoadInfo}
    */
-  static fromEnvironment() {
+  static fromEnvironment(environments) {
     let env = new Env();
-    let nodeConfigEnv = env.initParam('NODE_CONFIG_ENV');
-    let nodeEnv = env.initParam('NODE_ENV');
 
-    if (nodeConfigEnv) {
-      env.setEnv('nodeEnv', 'NODE_CONFIG_ENV');
-      nodeEnv = nodeConfigEnv;
-    } else if (nodeEnv) {
-      env.setEnv('nodeEnv', 'NODE_ENV');
-      env.setEnv('NODE_CONFIG_ENV', nodeEnv); //TODO: This is a bug asserted in the tests
+    if (environments !== undefined) {
+      environments = environments.split(',');
+      env.setEnv('nodeEnv', environments.join(','));
     } else {
-      nodeEnv = 'development';
-      env.setEnv('nodeEnv', 'default');
-      env.setEnv('NODE_ENV', nodeEnv);
-      env.setEnv('NODE_CONFIG_ENV', nodeEnv); //TODO: This is a bug asserted in the tests
-    }
+      let nodeConfigEnv = env.initParam('NODE_CONFIG_ENV');
+      let nodeEnv = env.initParam('NODE_ENV');
 
-    nodeEnv = nodeEnv.split(',');
+      if (nodeConfigEnv) {
+        env.setEnv('nodeEnv', 'NODE_CONFIG_ENV');
+        nodeEnv = nodeConfigEnv;
+      } else if (nodeEnv) {
+        env.setEnv('nodeEnv', 'NODE_ENV');
+        env.setEnv('NODE_CONFIG_ENV', nodeEnv); //TODO: This is a bug asserted in the tests
+      } else {
+        nodeEnv = 'development';
+        env.setEnv('nodeEnv', 'default');
+        env.setEnv('NODE_ENV', nodeEnv);
+        env.setEnv('NODE_CONFIG_ENV', nodeEnv); //TODO: This is a bug asserted in the tests
+      }
+
+      environments = nodeEnv.split(',');
+    }
 
     let configDir = env.initParam('NODE_CONFIG_DIR');
     configDir = configDir && _toAbsolutePath(configDir);
@@ -1026,7 +1189,7 @@ class LoadInfo {
     /** @type {LoadOptions} */
     let options = {
       configDir: configDir ?? DEFAULT_CONFIG_DIR,
-      nodeEnv,
+      nodeEnv: environments,
       hostName,
       parser,
       appInstance,

--- a/lib/util.js
+++ b/lib/util.js
@@ -941,6 +941,8 @@ class LoadInfo {
     }
 
     this.addConfig(fullFilename, configObject, fileContent);
+
+    return configObject;
   }
 
   /**
@@ -1026,7 +1028,9 @@ class LoadInfo {
     const moduleConfig = Util.cloneDeep(defaultProperties);
     let moduleDefaults;
 
-    if (this.sources.length > 0 && this.sources[0].name === 'Module Defaults') {
+    if (this.sources === undefined) {
+      moduleDefaults = {};
+    } else if (this.sources.length > 0 && this.sources[0].name === 'Module Defaults') {
       moduleDefaults = this.sources[0].parsed;
     } else {
       let source = { name: 'Module Defaults', parsed: {} };

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -9,6 +9,7 @@ const assert = require('assert');
 const Path = require('path');
 const util = require('../lib/util.js').Util;
 const LoadInfo = require('../lib/util.js').LoadInfo;
+const deferConfig = require('../defer').deferConfig;
 
 vows.describe('Tests for util functions')
   .addBatch({
@@ -548,6 +549,342 @@ vows.describe('Tests for util functions')
     },
   })
   .addBatch({
+    'LoadInfo.substituteDeep()': {
+      topic: function () {
+        var topic = {
+          TopLevel: 'SOME_TOP_LEVEL',
+          TestModule: {
+            parm1: "SINGLE_SECOND_LEVEL"
+          },
+          Customers: {
+            dbHost: 'DB_HOST',
+            dbName: 'DB_NAME',
+            oauth: {
+              key: 'OAUTH_KEY',
+              secret: 'OAUTH_SECRET'
+            }
+          }
+        };
+        return topic;
+      },
+      'returns an empty object if the variables mapping is empty': function (topic) {
+        let loadInfo = new LoadInfo();
+        let substituted = loadInfo.substituteDeep(topic, {});
+
+        assert.deepEqual(substituted, {});
+      },
+      'returns an empty object if none of the variables map to leaf strings': function (topic) {
+        let loadInfo = new LoadInfo();
+        let substituted = loadInfo.substituteDeep(topic, {NON_EXISTENT_VAR: 'ignore_this'});
+
+        assert.deepEqual(substituted, {});
+      },
+      'returns an object with keys matching down to mapped existing variables': function (topic) {
+        let loadInfo = new LoadInfo();
+        let substituted = loadInfo.substituteDeep(topic, {
+          'SOME_TOP_LEVEL': 5,
+          'DB_NAME': 'production_db',
+          'OAUTH_SECRET': '123456',
+          'PATH': 'ignore other environment variables'
+        });
+
+        assert.deepEqual(substituted, {
+          TopLevel: 5,
+          Customers: {
+            dbName: 'production_db',
+            oauth: {
+              secret: '123456'
+            }
+          }
+        });
+      },
+      'returns an object with keys matching down to mapped existing and defined variables': function (topic) {
+        let loadInfo = new LoadInfo();
+        let substituted = loadInfo.substituteDeep(topic, {
+          'SOME_TOP_LEVEL': 0,
+          'DB_HOST': undefined,
+          'DB_NAME': '',
+          'OAUTH_SECRET': 'false',
+          'OAUTH_KEY': 'null',
+          'PATH': ''
+        });
+
+        assert.deepEqual(substituted, {
+          TopLevel: 0,
+          Customers: {
+            oauth: {
+              key: 'null',
+              secret: 'false'
+            }
+          }
+        });
+      },
+      'returns an object with keys matching down to mapped existing variables with JSON content': function (topic) {
+        let loadInfo = new LoadInfo();
+        let substituted = loadInfo.substituteDeep(topic, {
+          'DB_HOST': '{"port":"3306","host":"example.com"}'
+        });
+
+        assert.deepEqual(substituted, {
+          Customers: {
+            dbHost: '{"port":"3306","host":"example.com"}'
+          }
+        });
+      },
+      'returns an object with keys matching down to mapped existing and defined variables with JSON content': function (topic) {
+        let dbHostObject = {
+          param1WithZero: 0,
+          param2WithFalse: false,
+          param3WithNull: null,
+          param4WithEmptyObject: {},
+          param5WithEmptyArray: [],
+          param6WithEmptyString: ''
+        };
+        let dbHostObjectWithUndefinedProperty = Object.assign({}, dbHostObject, {param7WithUndefined: undefined});
+
+        let loadInfo = new LoadInfo();
+        let substituted = loadInfo.substituteDeep(topic, {
+          'DB_HOST': JSON.stringify(dbHostObjectWithUndefinedProperty)
+        });
+
+        assert.deepEqual(substituted, {
+          Customers: {
+            dbHost: JSON.stringify(dbHostObject)
+          }
+        });
+      },
+      'returns an object with keys matching down to mapped and JSON-parsed existing variables': function (topic) {
+        topic.Customers.dbHost = {__name: 'DB_HOST', __format: 'json'};
+
+        let loadInfo = new LoadInfo();
+        let substituted = loadInfo.substituteDeep(topic, {
+          'DB_HOST': '{"port":"3306","host":"example.com"}'
+        });
+
+        assert.deepEqual(substituted, {
+          Customers: {
+            dbHost: {
+              port: '3306',
+              host: 'example.com'
+            }
+          }
+        });
+      },
+      'returns an object with keys matching down to mapped and JSON-parsed existing and defined variables': function (topic) {
+        let dbHostObject = {
+          param1WithZero: 0,
+          param2WithFalse: false,
+          param3WithNull: null,
+          param4WithEmptyObject: {},
+          param5WithEmptyArray: [],
+          param6WithEmptyString: ''
+        };
+        let dbHostObjectWithUndefinedProperty = Object.assign({}, dbHostObject, {param7WithUndefined: undefined});
+        let loadInfo = new LoadInfo();
+
+        topic.Customers.dbHost = {__name: 'DB_HOST', __format: 'json'};
+
+        let substituted = loadInfo.substituteDeep(topic, {
+          'DB_HOST': JSON.stringify(dbHostObjectWithUndefinedProperty)
+        });
+
+        assert.deepEqual(substituted, {
+          Customers: {
+            dbHost: dbHostObject
+          }
+        });
+      },
+      'throws an error for leaf Array values': function (topic) {
+        // Testing all the things in variable maps that don't make sense because ENV vars are always
+        // strings.
+        topic.Customers.dbHost = ['a', 'b', 'c'];
+
+        let loadInfo = new LoadInfo();
+
+        assert.throws(function () {
+          loadInfo.substituteDeep(topic, {
+            NON_EXISTENT_VAR: 'ignore_this'
+          });
+        });
+      },
+      'throws an error for leaf Boolean values': function (topic) {
+        topic.Customers.dbHost = false;
+
+        let loadInfo = new LoadInfo();
+
+        assert.throws(function () {
+          loadInfo.substituteDeep(topic, {
+            NON_EXISTENT_VAR: 'ignore_this'
+          });
+        });
+      },
+      'throws an error for leaf Numeric values': function (topic) {
+        topic.Customers.dbHost = 443;
+
+        let loadInfo = new LoadInfo();
+
+        assert.throws(function () {
+          loadInfo.substituteDeep(topic, {
+            NON_EXISTENT_VAR: 'ignore_this'
+          });
+        });
+      },
+      'throws an error for leaf null values': function (topic) {
+        topic.Customers.dbHost = null;
+
+        let loadInfo = new LoadInfo();
+
+        assert.throws(function () {
+          loadInfo.substituteDeep(topic, {
+            NON_EXISTENT_VAR: 'ignore_this'
+          });
+        });
+      },
+      'throws an error for leaf Undefined values': function (topic) {
+        topic.Customers.dbHost = undefined;
+
+        let loadInfo = new LoadInfo();
+
+        assert.throws(function () {
+          loadInfo.substituteDeep(topic, {
+            NON_EXISTENT_VAR: 'ignore_this'
+          });
+        });
+      },
+      'throws an error for leaf NaN values': function (topic) {
+        topic.Customers.dbHost = NaN;
+
+        let loadInfo = new LoadInfo();
+
+        assert.throws(function () {
+          loadInfo.substituteDeep(topic, {
+            NON_EXISTENT_VAR: 'ignore_this'
+          });
+        });
+      },
+      'throws an error with message describing variables name that throw a parser error': function(topic) {
+        var JSON_WITH_SYNTAX_ERROR = '{"port":"3306","host" "example.com"}'
+
+        topic.Customers.dbHost = {__name: 'DB_HOST', __format: 'json'};
+
+        let loadInfo = new LoadInfo();
+
+        assert.throws(function () {
+          loadInfo.substituteDeep(topic, {
+            'DB_HOST': JSON_WITH_SYNTAX_ERROR
+          });
+        },  /__format parser error in DB_HOST: /);
+      },
+    },
+    'LoadInfo.loadCustomEnvVars()': {
+      'should override from the environment variables': function () {
+        // Test Environment Variable Substitution
+        let expected = 'CUSTOM VALUE FROM JSON ENV MAPPING';
+        process.env.CUSTOM_JSON_ENVIRONMENT_VAR = expected;
+
+        let loadInfo = new LoadInfo({nodeEnv: 'production', configDir: __dirname + '/config'})
+        loadInfo.loadCustomEnvVars();
+        assert.deepStrictEqual(loadInfo.config.customEnvironmentVariables, { "mappedBy": { "json": expected } });
+      },
+      'should override from the environment variables': function () {
+        // Test Environment Variable Substitution
+        let expected = 'CUSTOM VALUE FROM JSON ENV MAPPING';
+        process.env.CUSTOM_JSON_ENVIRONMENT_VAR = expected;
+
+        try {
+          let loadInfo = new LoadInfo({nodeEnv: 'production', configDir: __dirname + '/config'})
+          loadInfo.loadCustomEnvVars();
+          assert.isObject(loadInfo.config.customEnvironmentVariables);
+          assert.isObject(loadInfo.config.customEnvironmentVariables.mappedBy);
+          assert.deepStrictEqual(loadInfo.config.customEnvironmentVariables.mappedBy, {"json": expected});
+        } finally {
+          delete process.env.CUSTOM_JSON_ENVIRONMENT_VAR;
+        }
+      },
+      'can handle boolean values': function () {
+        process.env.CUSTOM_BOOLEAN_TRUE_ENVIRONMENT_VAR = 'true';
+        process.env.CUSTOM_BOOLEAN_FALSE_ENVIRONMENT_VAR = 'false';
+        process.env.CUSTOM_BOOLEAN_ERROR_ENVIRONMENT_VAR = 'notProperBoolean';
+
+        try {
+          let loadInfo = new LoadInfo({nodeEnv: 'production', configDir: __dirname + '/config'})
+          loadInfo.loadCustomEnvVars();
+          assert.isObject(loadInfo.config.customEnvironmentVariables.mappedBy);
+          assert.deepStrictEqual(loadInfo.config.customEnvironmentVariables.mappedBy.formats,
+            { "booleanTrue": true, "booleanFalse": false, "notProperBoolean": false });
+        } finally {
+          delete process.env.CUSTOM_BOOLEAN_TRUE_ENVIRONMENT_VAR;
+          delete process.env.CUSTOM_BOOLEAN_FALSE_ENVIRONMENT_VAR;
+          delete process.env.CUSTOM_BOOLEAN_ERROR_ENVIRONMENT_VAR;
+        }
+      },
+      'can handle numeric values': function () {
+        // Test Environment variable substitution of numeric values
+        let numberInteger = 1001;
+        let numberFloat = 3.14
+        process.env.CUSTOM_NUMBER_INTEGER_ENVIRONMENT_VAR = numberInteger;
+        process.env.CUSTOM_NUMBER_FLOAT_ENVIRONMENT_VAR = numberFloat;
+        process.env.CUSTOM_NUMBER_EMPTY_ENVIRONMENT_VAR = '';
+        process.env.CUSTOM_NUMBER_STRING_ENVIRONMENT_VAR = 'String';
+
+        let loadInfo = new LoadInfo({nodeEnv: 'production', configDir: __dirname + '/config'})
+        loadInfo.loadCustomEnvVars();
+        assert.isObject(loadInfo.config.customEnvironmentVariables.mappedBy);
+        assert.deepStrictEqual(loadInfo.config.customEnvironmentVariables.mappedBy.formats,
+          { "numberInteger": 1001, "numberFloat": 3.14, "numberString": undefined });
+      }
+    },
+  })
+  .addBatch({
+    'Util.resolveDeferredConfigs()': {
+      'The function exists': function () {
+        assert.isFunction(util.resolveDeferredConfigs);
+      },
+      'expands values': function() {
+        let data = {
+          deferreds: {
+            foo: '3',
+            bar: deferConfig(() => {
+              return 4;
+            })
+          }
+        };
+
+        util.resolveDeferredConfigs(data);
+
+        assert.deepStrictEqual(data.deferreds, { foo: '3', bar: 4});
+      },
+      'works for arrays': function() {
+        let data = {
+          deferreds: {
+            foo: 2,
+            bar: [deferConfig(() => {
+              return 4;
+            })]
+          }
+        };
+
+        util.resolveDeferredConfigs(data);
+
+        assert.deepStrictEqual(data.deferreds, { foo: 2, bar: [4]});
+      },
+      'handles recursive expansion': function() {
+        let data = {
+          deferreds: {
+            foo: deferConfig(() => {
+              return 4;
+            }),
+            bar: deferConfig((config) => {
+              return `${config.deferreds.foo} interpolated`
+            })
+          }
+        };
+
+        util.resolveDeferredConfigs(data);
+
+        assert.deepStrictEqual(data.deferreds, { foo: 4, bar: '4 interpolated'});
+      }
+    },
     'Util.loadFileConfigs()': {
       'The function exists': function () {
         assert.isFunction(util.loadFileConfigs);
@@ -576,5 +913,25 @@ vows.describe('Tests for util functions')
       },
     },
   })
-  .export(module);
+  .addBatch({
+    'LoadInfo.load()': {
+      'The function exists': function () {
+        const loadInfo = new LoadInfo();
+        assert.isFunction(loadInfo.load);
+      },
+      'It can load data from a given directory': function () {
+        let loadInfo = new LoadInfo({configDir: __dirname + '/config'})
+        loadInfo.load();
+
+        assert.isObject(loadInfo.config.Customers);
+      },
+      'It merges in the provided data': function () {
+        let loadInfo = new LoadInfo({configDir: __dirname + '/config'})
+        loadInfo.load([{ name: 'a', config: {foo: 'bar'} }]);
+
+        assert.equal(loadInfo.config.foo, 'bar');
+      },
+    },
+  })
+.export(module);
 

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -8,7 +8,7 @@ const vows = require('vows');
 const assert = require('assert');
 const Path = require('path');
 const util = require('../lib/util.js').Util;
-const LoadInfo = require('../lib/util.js').LoadInfo;
+const Load = require('../lib/util.js').Load;
 const deferConfig = require('../defer').deferConfig;
 
 vows.describe('Tests for util functions')
@@ -408,69 +408,69 @@ vows.describe('Tests for util functions')
     },
   })
   .addBatch({
-    'LoadInfo.initParam()': {
+    'Load.initParam()': {
       topic: function () {
-        return new LoadInfo({});
+        return new Load({});
       },
-      'The function exists': function (loadInfo) {
-        assert.isFunction(loadInfo.initParam);
+      'The function exists': function (load) {
+        assert.isFunction(load.initParam);
       },
-      'looks up values': function (loadInfo) {
+      'looks up values': function (load) {
         process.env.NODE_CONFIG = '{"EnvOverride":{"parm4":100}}';
 
-        let result = loadInfo.initParam('NODE_CONFIG');
+        let result = load.initParam('NODE_CONFIG');
 
         assert.equal(result, '{"EnvOverride":{"parm4":100}}');
 
         delete process.env.NODE_CONFIG;
       },
-      'defaults on missing value up values': function (loadInfo) {
+      'defaults on missing value up values': function (load) {
         delete process.env.NODE_CONFIG;
 
-        let result = loadInfo.initParam('NODE_CONFIG', '{}');
+        let result = load.initParam('NODE_CONFIG', '{}');
 
         assert.equal(result, '{}');
       },
-      'tracks lookups': function (loadInfo) {
+      'tracks lookups': function (load) {
         delete process.env.NODE_CONFIG;
         delete process.env.NODE_CONFIG_FOO;
 
-        loadInfo.initParam('NODE_CONFIG', true);
-        loadInfo.initParam('NODE_CONFIG_FOO', "small");
+        load.initParam('NODE_CONFIG', true);
+        load.initParam('NODE_CONFIG_FOO', "small");
 
-        assert.equal(loadInfo.getEnv('NODE_CONFIG'), true);
-        assert.equal(loadInfo.getEnv('NODE_CONFIG_FOO'), "small");
+        assert.equal(load.getEnv('NODE_CONFIG'), true);
+        assert.equal(load.getEnv('NODE_CONFIG_FOO'), "small");
       },
     },
-    'LoadInfo.addConfig()': {
+    'Load.addConfig()': {
       topic: function () {
-        return new LoadInfo({});
+        return new Load({});
       },
-      'The function exists': function (loadInfo) {
-        assert.isFunction(loadInfo.addConfig);
+      'The function exists': function (load) {
+        assert.isFunction(load.addConfig);
       },
-      'adds new fields': function (loadInfo) {
-        loadInfo.addConfig("first", { foo: { field1: 'new'}});
-        assert.deepEqual(loadInfo.config, { foo: { field1: 'new' } });
+      'adds new fields': function (load) {
+        load.addConfig("first", { foo: { field1: 'new'}});
+        assert.deepEqual(load.config, { foo: { field1: 'new' } });
       },
-      'composes values': function (loadInfo) {
-        loadInfo.addConfig("second", { foo: { field2: 'another' } });
-        assert.deepEqual(loadInfo.config, { foo: { field1: 'new', field2: 'another' } });
+      'composes values': function (load) {
+        load.addConfig("second", { foo: { field2: 'another' } });
+        assert.deepEqual(load.config, { foo: { field1: 'new', field2: 'another' } });
       },
       'chains on itself': function () {
-        let loadInfo = new LoadInfo({});
-        loadInfo
+        let load = new Load({});
+        load
           .addConfig("first", {foo: {field1: 'blue'}})
           .addConfig("second", {foo: {field2: 'green'}});
 
-        assert.deepEqual(loadInfo.config, { foo: { field1: 'blue', field2: 'green' } });
+        assert.deepEqual(load.config, { foo: { field1: 'blue', field2: 'green' } });
       },
       'tracks the sources': function () {
-        let loadInfo = new LoadInfo({});
-        loadInfo.addConfig("first", { foo: { field1: 'new' }});
-        loadInfo.addConfig("second", { foo: { field2: 'another' }});
+        let load = new Load({});
+        load.addConfig("first", { foo: { field1: 'new' }});
+        load.addConfig("second", { foo: { field2: 'another' }});
 
-        assert.deepEqual(loadInfo.getSources(), [
+        assert.deepEqual(load.getSources(), [
           {
             name: 'first',
             parsed: { foo: { field1: 'new' } }
@@ -482,31 +482,31 @@ vows.describe('Tests for util functions')
         ]);
       }
     },
-    'LoadInfo.setModuleDefaults()': {
+    'Load.setModuleDefaults()': {
       topic: function () {
-        let loadInfo = new LoadInfo({});
-        loadInfo.addConfig("first", { foo: { field1: 'set'}});
-        return loadInfo;
+        let load = new Load({});
+        load.addConfig("first", { foo: { field1: 'set'}});
+        return load;
       },
-      'The function exists': function (loadInfo) {
-        assert.isFunction(loadInfo.setModuleDefaults);
+      'The function exists': function (load) {
+        assert.isFunction(load.setModuleDefaults);
       },
-      'adds new defaults': function (loadInfo) {
-        loadInfo.setModuleDefaults("foo", { field2: 'another'});
+      'adds new defaults': function (load) {
+        load.setModuleDefaults("foo", { field2: 'another'});
 
-        assert.deepEqual(loadInfo.config, { foo: { field1: 'set', field2: 'another' } });
+        assert.deepEqual(load.config, { foo: { field1: 'set', field2: 'another' } });
       },
-      'can be called multiple times for the same key': function (loadInfo) {
-        loadInfo.setModuleDefaults("foo", { field2: 'another'});
-        loadInfo.setModuleDefaults("foo", { field3: 'additional'});
+      'can be called multiple times for the same key': function (load) {
+        load.setModuleDefaults("foo", { field2: 'another'});
+        load.setModuleDefaults("foo", { field3: 'additional'});
 
-        assert.deepEqual(loadInfo.config, { foo: { field1: 'set', field2: 'another', field3: 'additional' } });
+        assert.deepEqual(load.config, { foo: { field1: 'set', field2: 'another', field3: 'additional' } });
       },
       'tracks the sources': function () {
-        let loadInfo = new LoadInfo({});
-        loadInfo.setModuleDefaults("foo", { field2: 'another'});
+        let load = new Load({});
+        load.setModuleDefaults("foo", { field2: 'another'});
 
-        assert.deepEqual(loadInfo.getSources(), [
+        assert.deepEqual(load.getSources(), [
           {
             name: 'Module Defaults',
             parsed: { foo: { field2: 'another' } }
@@ -514,40 +514,40 @@ vows.describe('Tests for util functions')
         ]);
       },
       'can disable tracking sources': function () {
-        let loadInfo = new LoadInfo({skipConfigSources: true});
-        loadInfo.setModuleDefaults("foo", { field2: 'another'});
+        let load = new Load({skipConfigSources: true});
+        load.setModuleDefaults("foo", { field2: 'another'});
 
-        assert.isEmpty(loadInfo.getSources());
+        assert.isEmpty(load.getSources());
       }
     },
-    'LoadInfo.loadFile()': {
+    'Load.loadFile()': {
       topic: function () {
-        return new LoadInfo({configDir: './config'});
+        return new Load({configDir: './config'});
       },
-      'The function exists': function(loadInfo) {
-        assert.isFunction(loadInfo.loadFile);
+      'The function exists': function(load) {
+        assert.isFunction(load.loadFile);
       },
-      'throws no error on missing file': function (loadInfo) {
-        assert.doesNotThrow(() => loadInfo.loadFile(Path.join(__dirname, './config/missing.json')));
+      'throws no error on missing file': function (load) {
+        assert.doesNotThrow(() => load.loadFile(Path.join(__dirname, './config/missing.json')));
       },
-      'throws error on other file issues': function (loadInfo) {
-        assert.throws(() => loadInfo.loadFile(Path.join(__dirname, './config/')));
+      'throws error on other file issues': function (load) {
+        assert.throws(() => load.loadFile(Path.join(__dirname, './config/')));
       },
-      'adds new values': function(loadInfo) {
-        loadInfo.loadFile(Path.join(__dirname, './config/default.json'));
+      'adds new values': function(load) {
+        load.loadFile(Path.join(__dirname, './config/default.json'));
 
-        assert.deepEqual(loadInfo.config.staticArray, [2,1,3]);
+        assert.deepEqual(load.config.staticArray, [2,1,3]);
       },
-      'uses an optional transform on the data': function(loadInfo) {
-        loadInfo.loadFile(Path.join(__dirname, './config/default-3.json'), () => { return { foo: "bar" } });
+      'uses an optional transform on the data': function(load) {
+        load.loadFile(Path.join(__dirname, './config/default-3.json'), () => { return { foo: "bar" } });
 
-        assert.equal(loadInfo.config.foo, "bar");
+        assert.equal(load.config.foo, "bar");
       },
       'tracks the sources': function () {
-        let loadInfo = new LoadInfo({configDir: './config'});
-        loadInfo.loadFile(Path.join(__dirname, './config/default.json'));
+        let load = new Load({configDir: './config'});
+        load.loadFile(Path.join(__dirname, './config/default.json'));
 
-        let sources = loadInfo.getSources();
+        let sources = load.getSources();
 
         assert.equal(sources.length, 1);
         assert.isTrue(sources[0].name.endsWith("/config/default.json"));
@@ -555,7 +555,7 @@ vows.describe('Tests for util functions')
     },
   })
   .addBatch({
-    'LoadInfo.substituteDeep()': {
+    'Load.substituteDeep()': {
       topic: function () {
         var topic = {
           TopLevel: 'SOME_TOP_LEVEL',
@@ -574,20 +574,20 @@ vows.describe('Tests for util functions')
         return topic;
       },
       'returns an empty object if the variables mapping is empty': function (topic) {
-        let loadInfo = new LoadInfo();
-        let substituted = loadInfo.substituteDeep(topic, {});
+        let load = new Load();
+        let substituted = load.substituteDeep(topic, {});
 
         assert.deepEqual(substituted, {});
       },
       'returns an empty object if none of the variables map to leaf strings': function (topic) {
-        let loadInfo = new LoadInfo();
-        let substituted = loadInfo.substituteDeep(topic, {NON_EXISTENT_VAR: 'ignore_this'});
+        let load = new Load();
+        let substituted = load.substituteDeep(topic, {NON_EXISTENT_VAR: 'ignore_this'});
 
         assert.deepEqual(substituted, {});
       },
       'returns an object with keys matching down to mapped existing variables': function (topic) {
-        let loadInfo = new LoadInfo();
-        let substituted = loadInfo.substituteDeep(topic, {
+        let load = new Load();
+        let substituted = load.substituteDeep(topic, {
           'SOME_TOP_LEVEL': 5,
           'DB_NAME': 'production_db',
           'OAUTH_SECRET': '123456',
@@ -605,8 +605,8 @@ vows.describe('Tests for util functions')
         });
       },
       'returns an object with keys matching down to mapped existing and defined variables': function (topic) {
-        let loadInfo = new LoadInfo();
-        let substituted = loadInfo.substituteDeep(topic, {
+        let load = new Load();
+        let substituted = load.substituteDeep(topic, {
           'SOME_TOP_LEVEL': 0,
           'DB_HOST': undefined,
           'DB_NAME': '',
@@ -626,8 +626,8 @@ vows.describe('Tests for util functions')
         });
       },
       'returns an object with keys matching down to mapped existing variables with JSON content': function (topic) {
-        let loadInfo = new LoadInfo();
-        let substituted = loadInfo.substituteDeep(topic, {
+        let load = new Load();
+        let substituted = load.substituteDeep(topic, {
           'DB_HOST': '{"port":"3306","host":"example.com"}'
         });
 
@@ -648,8 +648,8 @@ vows.describe('Tests for util functions')
         };
         let dbHostObjectWithUndefinedProperty = Object.assign({}, dbHostObject, {param7WithUndefined: undefined});
 
-        let loadInfo = new LoadInfo();
-        let substituted = loadInfo.substituteDeep(topic, {
+        let load = new Load();
+        let substituted = load.substituteDeep(topic, {
           'DB_HOST': JSON.stringify(dbHostObjectWithUndefinedProperty)
         });
 
@@ -662,8 +662,8 @@ vows.describe('Tests for util functions')
       'returns an object with keys matching down to mapped and JSON-parsed existing variables': function (topic) {
         topic.Customers.dbHost = {__name: 'DB_HOST', __format: 'json'};
 
-        let loadInfo = new LoadInfo();
-        let substituted = loadInfo.substituteDeep(topic, {
+        let load = new Load();
+        let substituted = load.substituteDeep(topic, {
           'DB_HOST': '{"port":"3306","host":"example.com"}'
         });
 
@@ -686,11 +686,11 @@ vows.describe('Tests for util functions')
           param6WithEmptyString: ''
         };
         let dbHostObjectWithUndefinedProperty = Object.assign({}, dbHostObject, {param7WithUndefined: undefined});
-        let loadInfo = new LoadInfo();
+        let load = new Load();
 
         topic.Customers.dbHost = {__name: 'DB_HOST', __format: 'json'};
 
-        let substituted = loadInfo.substituteDeep(topic, {
+        let substituted = load.substituteDeep(topic, {
           'DB_HOST': JSON.stringify(dbHostObjectWithUndefinedProperty)
         });
 
@@ -705,10 +705,10 @@ vows.describe('Tests for util functions')
         // strings.
         topic.Customers.dbHost = ['a', 'b', 'c'];
 
-        let loadInfo = new LoadInfo();
+        let load = new Load();
 
         assert.throws(function () {
-          loadInfo.substituteDeep(topic, {
+          load.substituteDeep(topic, {
             NON_EXISTENT_VAR: 'ignore_this'
           });
         });
@@ -716,10 +716,10 @@ vows.describe('Tests for util functions')
       'throws an error for leaf Boolean values': function (topic) {
         topic.Customers.dbHost = false;
 
-        let loadInfo = new LoadInfo();
+        let load = new Load();
 
         assert.throws(function () {
-          loadInfo.substituteDeep(topic, {
+          load.substituteDeep(topic, {
             NON_EXISTENT_VAR: 'ignore_this'
           });
         });
@@ -727,10 +727,10 @@ vows.describe('Tests for util functions')
       'throws an error for leaf Numeric values': function (topic) {
         topic.Customers.dbHost = 443;
 
-        let loadInfo = new LoadInfo();
+        let load = new Load();
 
         assert.throws(function () {
-          loadInfo.substituteDeep(topic, {
+          load.substituteDeep(topic, {
             NON_EXISTENT_VAR: 'ignore_this'
           });
         });
@@ -738,10 +738,10 @@ vows.describe('Tests for util functions')
       'throws an error for leaf null values': function (topic) {
         topic.Customers.dbHost = null;
 
-        let loadInfo = new LoadInfo();
+        let load = new Load();
 
         assert.throws(function () {
-          loadInfo.substituteDeep(topic, {
+          load.substituteDeep(topic, {
             NON_EXISTENT_VAR: 'ignore_this'
           });
         });
@@ -749,10 +749,10 @@ vows.describe('Tests for util functions')
       'throws an error for leaf Undefined values': function (topic) {
         topic.Customers.dbHost = undefined;
 
-        let loadInfo = new LoadInfo();
+        let load = new Load();
 
         assert.throws(function () {
-          loadInfo.substituteDeep(topic, {
+          load.substituteDeep(topic, {
             NON_EXISTENT_VAR: 'ignore_this'
           });
         });
@@ -760,10 +760,10 @@ vows.describe('Tests for util functions')
       'throws an error for leaf NaN values': function (topic) {
         topic.Customers.dbHost = NaN;
 
-        let loadInfo = new LoadInfo();
+        let load = new Load();
 
         assert.throws(function () {
-          loadInfo.substituteDeep(topic, {
+          load.substituteDeep(topic, {
             NON_EXISTENT_VAR: 'ignore_this'
           });
         });
@@ -773,24 +773,24 @@ vows.describe('Tests for util functions')
 
         topic.Customers.dbHost = {__name: 'DB_HOST', __format: 'json'};
 
-        let loadInfo = new LoadInfo();
+        let load = new Load();
 
         assert.throws(function () {
-          loadInfo.substituteDeep(topic, {
+          load.substituteDeep(topic, {
             'DB_HOST': JSON_WITH_SYNTAX_ERROR
           });
         },  /__format parser error in DB_HOST: /);
       },
     },
-    'LoadInfo.loadCustomEnvVars()': {
+    'Load.loadCustomEnvVars()': {
       'should override from the environment variables': function () {
         // Test Environment Variable Substitution
         let expected = 'CUSTOM VALUE FROM JSON ENV MAPPING';
         process.env.CUSTOM_JSON_ENVIRONMENT_VAR = expected;
 
-        let loadInfo = new LoadInfo({nodeEnv: 'production', configDir: __dirname + '/config'})
-        loadInfo.loadCustomEnvVars();
-        assert.deepStrictEqual(loadInfo.config.customEnvironmentVariables, { "mappedBy": { "json": expected } });
+        let load = new Load({nodeEnv: 'production', configDir: __dirname + '/config'})
+        load.loadCustomEnvVars();
+        assert.deepStrictEqual(load.config.customEnvironmentVariables, { "mappedBy": { "json": expected } });
       },
       'should override from the environment variables': function () {
         // Test Environment Variable Substitution
@@ -798,11 +798,11 @@ vows.describe('Tests for util functions')
         process.env.CUSTOM_JSON_ENVIRONMENT_VAR = expected;
 
         try {
-          let loadInfo = new LoadInfo({nodeEnv: 'production', configDir: __dirname + '/config'})
-          loadInfo.loadCustomEnvVars();
-          assert.isObject(loadInfo.config.customEnvironmentVariables);
-          assert.isObject(loadInfo.config.customEnvironmentVariables.mappedBy);
-          assert.deepStrictEqual(loadInfo.config.customEnvironmentVariables.mappedBy, {"json": expected});
+          let load = new Load({nodeEnv: 'production', configDir: __dirname + '/config'})
+          load.loadCustomEnvVars();
+          assert.isObject(load.config.customEnvironmentVariables);
+          assert.isObject(load.config.customEnvironmentVariables.mappedBy);
+          assert.deepStrictEqual(load.config.customEnvironmentVariables.mappedBy, {"json": expected});
         } finally {
           delete process.env.CUSTOM_JSON_ENVIRONMENT_VAR;
         }
@@ -813,10 +813,10 @@ vows.describe('Tests for util functions')
         process.env.CUSTOM_BOOLEAN_ERROR_ENVIRONMENT_VAR = 'notProperBoolean';
 
         try {
-          let loadInfo = new LoadInfo({nodeEnv: 'production', configDir: __dirname + '/config'})
-          loadInfo.loadCustomEnvVars();
-          assert.isObject(loadInfo.config.customEnvironmentVariables.mappedBy);
-          assert.deepStrictEqual(loadInfo.config.customEnvironmentVariables.mappedBy.formats,
+          let load = new Load({nodeEnv: 'production', configDir: __dirname + '/config'})
+          load.loadCustomEnvVars();
+          assert.isObject(load.config.customEnvironmentVariables.mappedBy);
+          assert.deepStrictEqual(load.config.customEnvironmentVariables.mappedBy.formats,
             { "booleanTrue": true, "booleanFalse": false, "notProperBoolean": false });
         } finally {
           delete process.env.CUSTOM_BOOLEAN_TRUE_ENVIRONMENT_VAR;
@@ -833,10 +833,10 @@ vows.describe('Tests for util functions')
         process.env.CUSTOM_NUMBER_EMPTY_ENVIRONMENT_VAR = '';
         process.env.CUSTOM_NUMBER_STRING_ENVIRONMENT_VAR = 'String';
 
-        let loadInfo = new LoadInfo({nodeEnv: 'production', configDir: __dirname + '/config'})
-        loadInfo.loadCustomEnvVars();
-        assert.isObject(loadInfo.config.customEnvironmentVariables.mappedBy);
-        assert.deepStrictEqual(loadInfo.config.customEnvironmentVariables.mappedBy.formats,
+        let load = new Load({nodeEnv: 'production', configDir: __dirname + '/config'})
+        load.loadCustomEnvVars();
+        assert.isObject(load.config.customEnvironmentVariables.mappedBy);
+        assert.deepStrictEqual(load.config.customEnvironmentVariables.mappedBy.formats,
           { "numberInteger": 1001, "numberFloat": 3.14, "numberString": undefined });
       }
     },
@@ -920,28 +920,28 @@ vows.describe('Tests for util functions')
     },
   })
   .addBatch({
-    'LoadInfo.load()': {
+    'Load.scan()': {
       'The function exists': function () {
-        const loadInfo = new LoadInfo();
-        assert.isFunction(loadInfo.load);
+        const load = new Load();
+        assert.isFunction(load.scan);
       },
       'It can load data from a given directory': function () {
-        let loadInfo = new LoadInfo({configDir: __dirname + '/config'})
-        loadInfo.load();
+        let load = new Load({configDir: __dirname + '/config'})
+        load.scan();
 
-        assert.isObject(loadInfo.config.Customers);
+        assert.isObject(load.config.Customers);
       },
       'It merges in the provided data': function () {
-        let loadInfo = new LoadInfo({configDir: __dirname + '/config'})
-        loadInfo.load([{ name: 'a', config: {foo: 'bar'} }]);
+        let load = new Load({configDir: __dirname + '/config'})
+        load.scan([{ name: 'a', config: {foo: 'bar'} }]);
 
-        assert.equal(loadInfo.config.foo, 'bar');
+        assert.equal(load.config.foo, 'bar');
       },
       'can disable source accumulation': function() {
-        let loadInfo = new LoadInfo({configDir: __dirname + '/config', skipConfigSources: true});
-        loadInfo.load();
+        let load = new Load({configDir: __dirname + '/config', skipConfigSources: true});
+        load.scan();
 
-        assert.isEmpty(loadInfo.getSources());
+        assert.isEmpty(load.getSources());
       }
     },
   })

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -512,6 +512,12 @@ vows.describe('Tests for util functions')
             parsed: { foo: { field2: 'another' } }
           }
         ]);
+      },
+      'can disable tracking sources': function () {
+        let loadInfo = new LoadInfo({skipConfigSources: true});
+        loadInfo.setModuleDefaults("foo", { field2: 'another'});
+
+        assert.isEmpty(loadInfo.getSources());
       }
     },
     'LoadInfo.loadFile()': {
@@ -931,6 +937,12 @@ vows.describe('Tests for util functions')
 
         assert.equal(loadInfo.config.foo, 'bar');
       },
+      'can disable source accumulation': function() {
+        let loadInfo = new LoadInfo({configDir: __dirname + '/config', skipConfigSources: true});
+        loadInfo.load();
+
+        assert.isEmpty(loadInfo.getSources());
+      }
     },
   })
 .export(module);

--- a/test/19-custom-environment-variables.js
+++ b/test/19-custom-environment-variables.js
@@ -68,6 +68,31 @@ vows.describe('Testing custom environment variable overrides')
                 assert.deepStrictEqual(topic.config.testJSONValue,topic.jsonValue);
             },
         },
+        'getCustomEnvVars()': {
+            topic: function () {
+                const testValue = 'from env1';
+                const jsonValue = {
+                    fromJS: false,
+                    type: 'stringified JSON'
+                }
+                process.env.TEST_VALUE = testValue;
+                process.env.TEST_JSON_VALUE = JSON.stringify(jsonValue);
+
+                // Change the configuration directory for testing
+                process.env.NODE_CONFIG_DIR = __dirname + '/config';
+                var config = requireUncached(__dirname + '/../lib/config');
+                return {
+                     config,
+                     testValue,
+                     jsonValue
+                 };
+            },
+            'should override from the environment variables': function(topic) {
+                let results = topic.config.util.getCustomEnvVars(__dirname + '/19-config')
+                assert.strictEqual(results.testValue, topic.testValue);
+                assert.deepStrictEqual(results.testJSONValue, topic.jsonValue);
+            },
+        },
     },
 })
 .export(module);


### PR DESCRIPTION
This finishes most of the extraction work of code exposed in Config.util that has been earmarked for removal for the last few years.

These changes are sufficient to support some setModuleDefaults() patterns I've encountered, and writing CI/CD support tools for projects that use node-config in fairly heavy rotation.

This also covers some of the bullet points in #569 