### PR TITLE
Segregate defaults data from config data, so deferreds and multiple setModuleDefaults calls can be applied properly.

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -459,6 +459,7 @@ class Util {
    * @param object {Object} - Object to set the property on
    * @param property {string|string[]} - The property name to get (as an array or '.' delimited string)
    * @param value {*} - value to set, ignoring null
+   * @return {*} - the given value
    */
   static setPath(object, property, value) {
     const path = Array.isArray(property) ? property : property.split('.');
@@ -480,6 +481,8 @@ class Util {
         next = next[name] = {};
       }
     }
+
+    return value;
   }
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -774,11 +774,13 @@ class Load {
    * @param options {LoadOptions=} - defaults to reading from environment variables
    */
   constructor(options, env = new Env()) {
-    this.config = {};
     this.env = env;
     this.options = { ...DEFAULT_OPTIONS, ...options };
     this.sources = this.options.skipConfigSources ? undefined : [];
     this.parser = this.options.parser;
+    this.config = {};
+    this.defaults = undefined;
+    this.unmerged = undefined;
   }
 
   /**
@@ -1025,23 +1027,25 @@ class Load {
    * @return {Object} - The module level configuration object.
    */
   setModuleDefaults(moduleName, defaultProperties) {
-    const moduleConfig = Util.cloneDeep(defaultProperties);
-    let moduleDefaults;
+    if (this.defaults === undefined) {
+      this.defaults = {};
+      this.unmerged = {};
 
-    if (this.sources === undefined) {
-      moduleDefaults = {};
-    } else if (this.sources.length > 0 && this.sources[0].name === 'Module Defaults') {
-      moduleDefaults = this.sources[0].parsed;
-    } else {
-      let source = { name: 'Module Defaults', parsed: {} };
-      this.sources.splice(0, 0, source);
-      moduleDefaults = source.parsed;
+      if (this.sources) {
+        this.sources.splice(0, 0, { name: 'Module Defaults', parsed: this.defaults });
+      }
     }
 
     const path = moduleName.split('.');
-    Util.setPath(moduleDefaults, path, Util.cloneDeep(defaultProperties)); // TODO: This clobber is from the original code, and is a bug
+    const defaults = Util.setPath(this.defaults, path, Util.getPath(this.defaults, path) ?? {});
 
-    Util.extendDeep(moduleConfig, Util.getPath(this.config, path) || {});
+    Util.extendDeep(defaults, defaultProperties);
+
+    const original =
+      Util.getPath(this.unmerged, path) ??
+      Util.setPath(this.unmerged, path, Util.getPath(this.config, path) ?? {});
+
+    const moduleConfig = Util.extendDeep({}, defaults, original);
     Util.setPath(this.config, path, moduleConfig);
 
     return moduleConfig;

--- a/lib/util.js
+++ b/lib/util.js
@@ -1047,6 +1047,7 @@ class Load {
 
     const moduleConfig = Util.extendDeep({}, defaults, original);
     Util.setPath(this.config, path, moduleConfig);
+    Util.resolveDeferredConfigs(this.config);
 
     return moduleConfig;
   }

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -533,6 +533,14 @@ vows.describe('Tests for util functions')
 
         assert.deepEqual(load.config, { foo: { field1: 'set', field2: 'nevermind'} });
       },
+      'handles deferred values': function() {
+        let load = new Load({skipConfigSources: true});
+
+        load.addConfig("first", { foo: { field1: 'set' }});
+        load.setModuleDefaults("foo", { field2: 'another', deferredField: deferConfig((cfg) => `${cfg.foo.field1}3`) });
+
+        assert.deepEqual(load.config, { foo: { field1: 'set', field2: 'another', deferredField: 'set3' } });
+      },
       'tracks the sources': function () {
         let load = new Load({});
         load.setModuleDefaults("foo", { field2: 'another'});
@@ -549,7 +557,7 @@ vows.describe('Tests for util functions')
         load.setModuleDefaults("foo", { field2: 'another'});
 
         assert.isEmpty(load.getSources());
-      }
+      },
     },
     'Load.loadFile()': {
       topic: function () {

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -405,6 +405,10 @@ vows.describe('Tests for util functions')
         util.setPath(topic, 'EnvOverride.oauth.secret', 'ANOTHER');
         assert.equal(topic.EnvOverride.oauth.secret, 'ANOTHER');
       },
+      'returns the given value': function (topic) {
+        let input = { foo: "3"};
+        assert.equal(util.setPath(topic, 'some.path', input), input);
+      }
     },
   })
   .addBatch({
@@ -989,6 +993,8 @@ vows.describe('Tests for util functions')
         assert.deepStrictEqual(data.deferreds, { foo: 4, bar: '4 interpolated'});
       }
     },
+  })
+  .addBatch({
     'Util.loadFileConfigs()': {
       'The function exists': function () {
         assert.isFunction(util.loadFileConfigs);


### PR DESCRIPTION
This fixes:
 - #687 
 - #822
 - #827  
