### PR TITLE
Switch to c8 for code coverage.

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,11 +26,11 @@
   },
   "devDependencies": {
     "@types/node": "^7.0.8",
+    "c8": "^10.1.3",
     "coffeescript": "2.2.4",
     "cson": "^3.0.1",
     "hjson": "^1.2.0",
     "js-yaml": "^3.2.2",
-    "nyc": "^15.1.0",
     "properties": "~1.2.1",
     "request": "^2.88.2",
     "semver": "5.3.0",
@@ -48,19 +48,16 @@
   "engines": {
     "node": ">= 20.0.0"
   },
-  "nyc": {
+  "c8": {
     "include": [
       "*.js",
       "lib/**/*.js"
-    ],
-    "extension": [
-      ".js"
     ],
     "report-dir": "./coverage",
     "reporter": "lcov"
   },
   "scripts": {
-    "test": "nyc vows test/*.js --spec",
-    "vows": "nyc vows"
+    "test": "c8 vows test/*.js --spec",
+    "vows": "c8 vows"
   }
 }


### PR DESCRIPTION
c8 is compatible with nyc but uses nodejs' internal tooling for code coverage. 

One of the consequences of switching to this is that we no longer need to filter out the .ts tests from coverage, as it seems not to interact with require.extensions.