### PR TITLE
Improve get performance regression

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -18,9 +18,9 @@ function loadConfig() {
 }
 
 const benchmarks = new Benchmark({
-  '3.3.12': 'config@3.3.12',
   '4.0.1': 'config@4.0.1',
   '4.2.0': 'config@4.2.0',
+  '4.3.0': 'config@4.3.0',
   'trunk': 'git@github.com:node-config/node-config.git',
   'branch': { location: __dirname + '/../' },
 });
@@ -37,6 +37,9 @@ benchmarks.suite('access functions', function(suite) {
   minSamples: 50,
   setup: (client) => {
     let keys = Object.keys(client);
+
+    client.get('util');
+
     global.gc();
     return keys;
   }
@@ -56,7 +59,6 @@ benchmarks.suite('Util functions', function(suite) {
     const { Util } = require(path.join(location, "lib/util.js"));
     return { Util };
   },
-  skip: ['3.3.12']
 });
 
 benchmarks.suite('config.util functions', function(suite) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -10,8 +10,8 @@
 /** @typedef {typeof import('./../parser')} Parser */
 const { Util, Load, RawConfig } = require('./util.js');
 const Path = require('path');
-const LOAD_SYMBOL = Symbol('load');
 
+const LOAD_SYMBOL = Symbol('load');
 const DEFAULT_CLONE_DEPTH = 20;
 
 /**
@@ -60,8 +60,8 @@ class ConfigClass {
    */
   constructor(load) {
     this[LOAD_SYMBOL] = load;
-    Util.extendDeep(this, load.config);
 
+    Util.extendDeep(this, load.config);
     Util.makeHidden(this, 'util', new ConfigUtils(this));
     this.util.attachProtoDeep(this);
     // Perform strictness checks and possibly throw an exception.
@@ -87,11 +87,14 @@ class ConfigClass {
     }
 
     // Make configurations immutable after first get (unless disabled)
-    if (Object.isExtensible(this)) {
-      const load = this[LOAD_SYMBOL];
+    const load = this[LOAD_SYMBOL];
+    if (load.updated) {
+      load.updated = false;
 
       if (!load.initParam('ALLOW_CONFIG_MUTATIONS', false)) {
-        this.util.makeImmutable();
+        if (Object.isExtensible(this)) {
+          this.util.makeImmutable();
+        }
       }
     }
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -985,6 +985,8 @@ class Load {
     this.defaults = undefined;
     /** @type {Record<string, any> | undefined} */
     this.unmerged = undefined;
+    /** @type {boolean} */
+    this.updated = true;
   }
 
   /**
@@ -1072,6 +1074,8 @@ class Load {
    * @return {Load} this
    */
   addConfig(name, values, original) {
+    this.updated = true;
+
     Util.extendDeep(this.config, values);
 
     if (name && this.sources) {
@@ -1233,6 +1237,8 @@ class Load {
    * @return {Object} - The module level configuration object.
    */
   setModuleDefaults(moduleName, defaultProperties) {
+    this.updated = true;
+
     if (this.defaults === undefined) {
       this.defaults = {};
       this.unmerged = {};


### PR DESCRIPTION
Fixes #886 

```

 ⇒ 3.3.12                  ▏██████████████████▌─▕ 1,066,871 op/s | 37 samples | (baseline)
 ⇒ 4.0.1                   ▏███████████████████▌▕ 1,124,882 op/s | 37 samples | (1.05x faster)
 ⇒ 4.2.0                   ▏███████████████████▌▕ 1,147,226 op/s | 36 samples | (1.08x faster)
 ⇒ trunk                   ▏████████████████▌───▕ 969,726 op/s | 36 samples | (0.91x slower)
 ⇒ branch                  ▏████████████████████▕ 1,149,071 op/s | 37 samples | (1.08x faster)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration handling so recent updates are honored and configs aren’t prematurely locked.
  * Stricter validation flow to surface configuration issues earlier.

* **Chores**
  * Improved update-tracking so configuration changes are reliably detected.
  * Updated performance benchmark entries and re-enabled an older version for comparison.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->