### PR TITLE
Don't install dependencies younger than a week old.

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 # Prevent accidental publish to private repository
 registry=https://registry.npmjs.org/
+minimumReleaseAge=7


### PR DESCRIPTION
This flag is meant to prevent supply chain attacks in compatible npm versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Release configuration updated to set the minimum release age to 7 (adjusts timing controls for releases). Existing registry and publish safeguards remain unchanged. This increases the minimum time before a release is eligible, helping reduce accidental or premature releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->