### PR TITLE
4.4 branch: Guard against odd object prototypes triggered by changes in TOML 4.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     branches:
       - master
+      - '4.4'
 
 concurrency:
   group: pr-checks-${{ github.head_ref }}

--- a/lib/util.js
+++ b/lib/util.js
@@ -188,7 +188,7 @@ class Util {
             get(target, property, receiver) {
               // Bypass proxy receiver for properties directly on the target (e.g., RegExp.prototype.source)
               // or properties that are not functions to prevent errors related to internal object methods.
-              if (target.hasOwnProperty(property) || (property in target && typeof target[property] !== 'function')) {
+              if (Object.hasOwn(target, property) || (property in target && typeof target[property] !== 'function')) {
                 return Reflect.get(target, property);
               }
 


### PR DESCRIPTION
Note that test in 0-util.js:

    assert.deepStrictEqual(result.config.messages, [...

Still fails with toml 4.1 because there is no prototype on messages, which is problematic

Fixes #911 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved object immutability property detection to use more reliable methods.

* **Chores**
  * Updated continuous integration workflow to include additional branch for automated testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->