### PR TITLE
Fix resolveAsyncConfigs leaving promises in the exported config

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -446,12 +446,16 @@ class Util {
   /**
    * Used to resolve configs that have async functions.
    *
+   * Replaces every promise-valued property on the given config object with its
+   * resolved value, so that subsequent (synchronous) `config.get` calls return
+   * plain values.
+   *
    * NOTE: Do not use `config.get` before executing this method, it will freeze the config object
    *
    * This replaces ./async.js, which is deprecated.
    *
-   * @param config
-   * @returns {Promise<void>}
+   * @param config the main config object, returned from require('config')
+   * @returns {Promise<typeof config>} resolves with the given config object once all promises are resolved
    */
   static async resolveAsyncConfigs(config) {
     const promises = [];
@@ -471,15 +475,23 @@ class Util {
         if (property.constructor === Object) {
           _iterate(property);
         } else if (property.constructor === Array) {
-          for (let entry of property) {
+          for (let index = 0; index < property.length; index++) {
+            const entry = property[index];
+
             if (entry instanceof Promise) {
-              promises.push(entry);
+              promises.push(entry.then((value) => {
+                Object.defineProperty(property, index, { value });
+              }));
             } else {
               _iterate(entry);
             }
           }
         } else if (property instanceof Promise) {
-          promises.push(property);
+          promises.push(property.then((value) => {
+            // defineProperty, because the property may be a non-writable value
+            // left behind by an async defer function (see ./defer.js)
+            Object.defineProperty(prop, name, { value });
+          }));
         }
         // else: Nothing to do. Keep the property how it is.
       }
@@ -488,6 +500,8 @@ class Util {
     _iterate(config);
 
     await Promise.all(promises);
+
+    return config;
   }
 
   /**

--- a/lib/util.js
+++ b/lib/util.js
@@ -455,7 +455,6 @@ class Util {
    * This replaces ./async.js, which is deprecated.
    *
    * @param config the main config object, returned from require('config')
-   * @returns {Promise<typeof config>} resolves with the given config object once all promises are resolved
    */
   static async resolveAsyncConfigs(config) {
     const promises = [];
@@ -500,8 +499,6 @@ class Util {
     _iterate(config);
 
     await Promise.all(promises);
-
-    return config;
   }
 
   /**

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -1383,6 +1383,52 @@ describe('Tests for util functions', function () {
 
       assert.deepStrictEqual(data.deferreds, {foo: 4, bar: '4 interpolated'});
     });
+
+    it('replaces plain promise properties with their resolved values', async function () {
+      let data = {
+        fromPromise: Promise.resolve('resolved value'),
+        untouched: 'as-is'
+      };
+
+      await util.resolveAsyncConfigs(data);
+
+      assert.deepStrictEqual(data, {fromPromise: 'resolved value', untouched: 'as-is'});
+    });
+
+    it('replaces promises found in nested objects and arrays', async function () {
+      let data = {
+        nested: {secret: Promise.resolve('shhh')},
+        list: [1, Promise.resolve(2), {deep: Promise.resolve(3)}]
+      };
+
+      await util.resolveAsyncConfigs(data);
+
+      assert.deepStrictEqual(data, {nested: {secret: 'shhh'}, list: [1, 2, {deep: 3}]});
+    });
+
+    it('resolves promises copied into another object, such as the exported config', async function () {
+      // Simulates how the exported config singleton is built: extendDeep copies the
+      // promise reference before the deferred write-back can replace it on the source.
+      let source = {
+        deferreds: {
+          fromDatabase: deferConfig(async () => setTimeout(1, 'secret'))
+        }
+      };
+      util.resolveDeferredConfigs(source);
+
+      let copy = {};
+      util.extendDeep(copy, source);
+
+      await util.resolveAsyncConfigs(copy);
+
+      assert.deepStrictEqual(copy.deferreds, {fromDatabase: 'secret'});
+    });
+
+    it('rejects when a config promise rejects', async function () {
+      let data = {broken: Promise.reject(new Error('boom'))};
+
+      await assert.rejects(() => util.resolveAsyncConfigs(data), /boom/);
+    });
   });
 
   describe('Util.loadFileConfigs()', function() {

--- a/test/31-async-configs.js
+++ b/test/31-async-configs.js
@@ -1,0 +1,53 @@
+import { describe, it, before } from 'node:test';
+import assert from 'assert';
+import { Util } from '../lib/util.js';
+import { requireUncached } from './_utils/requireUncached.mjs';
+
+// Test resolving async values on the exported config object.
+//
+// Regression test: the exported config is a copy of the internally loaded config,
+// so async deferred values must be resolved onto the exported object itself.
+// Resolving them only on the internal object leaves promises behind in config.get().
+describe('Tests for async values on the exported config', function() {
+  let CONFIG;
+
+  before(async () => {
+    // Change the configuration directory for testing
+    process.env.NODE_CONFIG_DIR = import.meta.dirname + '/31-config';
+
+    // Hard-code $NODE_ENV=test for testing
+    process.env.NODE_ENV = 'test';
+
+    process.env.NODE_APP_INSTANCE = '';
+
+    CONFIG = await requireUncached('./lib/config.mjs');
+
+    await Util.resolveAsyncConfigs(CONFIG);
+  });
+
+  describe('Util.resolveAsyncConfigs() on the exported config', function() {
+    it('config.get() returns the resolved value of an async defer, not a promise', function() {
+      assert.strictEqual(CONFIG.get('fromAsyncDefer'), 'async defer value');
+    });
+
+    it('config.get() returns the resolved value of a plain promise', function() {
+      assert.strictEqual(CONFIG.get('fromPromise'), 'plain promise value');
+    });
+
+    it('async defer functions can compose other async values', function() {
+      assert.strictEqual(CONFIG.get('composed'), 'async defer value and static');
+    });
+
+    it('resolves async values in nested objects', function() {
+      assert.strictEqual(CONFIG.get('nested.fromAsyncDefer'), 'nested value');
+    });
+
+    it('resolves async values in arrays', function() {
+      assert.deepStrictEqual([...CONFIG.get('list')], ['first', 'second']);
+    });
+
+    it('leaves unrelated values untouched', function() {
+      assert.strictEqual(CONFIG.get('staticValue'), 'static');
+    });
+  });
+});

--- a/test/31-config/default.js
+++ b/test/31-config/default.js
@@ -1,0 +1,19 @@
+const { setTimeout } = require('node:timers/promises');
+
+module.exports = ({defer}) => ({
+  staticValue: 'static',
+  fromAsyncDefer: defer(async () => {
+    return setTimeout(1, 'async defer value');
+  }),
+  fromPromise: setTimeout(1, 'plain promise value'),
+  composed: defer(async function (cfg) {
+    return `${await cfg.fromAsyncDefer} and ${this.staticValue}`;
+  }),
+  nested: {
+    fromAsyncDefer: defer(async () => setTimeout(1, 'nested value')),
+  },
+  list: [
+    'first',
+    defer(async () => setTimeout(1, 'second')),
+  ],
+});


### PR DESCRIPTION
Fixes #925

`Util.resolveAsyncConfigs` only awaited the promises it found — it never wrote the resolved values back. For async `defer` functions the write-back in `defer.js` lands on the internally loaded config, but the exported config is a *copy* of it (`Util.extendDeep` in the `ConfigClass` constructor copies the promise reference), so `config.get()` kept returning promises instead of values:

```js
const { Util } = require('config/lib/util');
const config = require('config');

Util.resolveAsyncConfigs(config).then(() => {
  config.get('fromDatabase'); // Promise { 'secret' } — expected 'secret'
});
```

Since v5 also removed `config/async.js` (whose `asyncConfig` did perform this write-back in 4.x), there was no working way left to resolve async values for synchronous `config.get()` access, despite the wiki documenting exactly this pattern ([Special features for JavaScript configuration files → Promises and async functions](https://github.com/node-config/node-config/wiki/Special-features-for-JavaScript-configuration-files#promises-and-async-functions)).

### Changes

- `Util.resolveAsyncConfigs` now replaces each promise it finds with its resolved value on the object it was given (using `Object.defineProperty`, since async `defer` write-backs can leave non-writable properties behind), restoring the removed `config/async.js` behavior.
- It resolves with the config object again, so the wiki's `resolveAsyncConfigs(config).then(config => ...)` chaining works.
- Unit tests for the write-back (plain promises, nesting, arrays, the copied-object case, rejections).
- `test/31-async-configs.js`: end-to-end regression test through the real exported config object and `config.get()`. The existing unit tests operate on plain objects, where the `defer.js` write-back masks the problem — that's why this slipped through.

No API changes; `npm run ci` (types + 331 tests) passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Asynchronous configuration values are now resolved throughout nested objects and arrays.
  - Resolved configuration is returned for immediate use.
  - Non-writable configuration properties are handled during resolution.
  - Rejected asynchronous values now propagate correctly.

- **Tests**
  - Added coverage for deferred values, nested configurations, arrays, composed values, and static settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->