### PR TITLE
types: restore full typedefs from DefinitelyTyped

### DIFF
--- a/lib/config.mjs
+++ b/lib/config.mjs
@@ -137,7 +137,11 @@ class ConfigClass {
  * The exported configuration instance type.
  * This is here because the Config class is not a named export and this is how we get
  * the exported configuration instance type.
- * @typedef {ConfigClass} Config
+ *
+ * When NodeConfig.Schema has been augmented (see lib/schema.ts), get() is
+ * constrained to the schema's dot-notation paths with typed return values,
+ * and configuration properties are typed for direct access.
+ * @typedef {Omit<ConfigClass, 'get'> & { get: import('./schema.js').ConfigGet } & NodeConfig.Schema} Config
  */
 
 /**

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -36,5 +36,10 @@ type Augmented = keyof NodeConfig.Schema extends never ? false : true;
  * the schema is known, the classic untyped signature otherwise.
  */
 export type ConfigGet = Augmented extends true
-  ? <P extends Paths<NodeConfig.Schema>>(property: P) => Get<NodeConfig.Schema, P>
+  ? {
+      // 1: path inference — get('port') infers P = 'port', returns Get<Schema, 'port'>
+      <P extends Paths<NodeConfig.Schema>>(property: P): Get<NodeConfig.Schema, P>;
+      // 2: explicit-T compat — get<number>('port') lands here
+      <T>(property: Paths<NodeConfig.Schema>): T;
+    }
   : <T>(property: string) => T;

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -1,0 +1,40 @@
+// Type-level support for typed config.get(). This file emits declarations
+// only (types/lib/schema.d.ts) — it has no runtime counterpart.
+import type { Get, Paths } from 'dot.paths';
+
+declare global {
+  namespace NodeConfig {
+    /**
+     * Augment this interface with the shape of your configuration to get
+     * dot-notation path autocomplete and correctly typed return values
+     * from config.get():
+     *
+     * <pre>
+     * declare global {
+     *   namespace NodeConfig {
+     *     interface Schema {
+     *       port: number;
+     *       customer: {
+     *         dbName: string;
+     *       };
+     *     }
+     *   }
+     * }
+     * </pre>
+     *
+     * When left unaugmented, config.get() keeps its untyped signature.
+     */
+    interface Schema {}
+  }
+}
+
+/** Resolves to true once NodeConfig.Schema has been augmented. */
+type Augmented = keyof NodeConfig.Schema extends never ? false : true;
+
+/**
+ * The type of config.get(): path-constrained with typed return values once
+ * the schema is known, the classic untyped signature otherwise.
+ */
+export type ConfigGet = Augmented extends true
+  ? <P extends Paths<NodeConfig.Schema>>(property: P) => Get<NodeConfig.Schema, P>
+  : <T>(property: string) => T;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
+        "dot.paths": "^0.1.0",
         "json5": "^2.2.3"
       },
       "devDependencies": {
@@ -29,7 +30,7 @@
         "yaml": "^2.8.2"
       },
       "engines": {
-        "node": ">= 20.0.0"
+        "node": ">= 20.11.0"
       }
     },
     "node_modules/@bcoe/v8-coverage": {
@@ -942,6 +943,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dot.paths": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/dot.paths/-/dot.paths-0.1.0.tgz",
+      "integrity": "sha512-JhnbIboGe8ccS+ySWEBJ7+jxLQLl9uuWZeJfBeWK49iIZdXezFptOYjP+GX9MpRrJ86nw7qNHoigi7QCiEOn7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/eachr": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "5.0.1",
       "license": "MIT",
       "dependencies": {
-        "dot.paths": "^0.1.0",
+        "dot.paths": "^0.1.1",
         "json5": "^2.2.3"
       },
       "devDependencies": {
@@ -946,9 +946,9 @@
       }
     },
     "node_modules/dot.paths": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/dot.paths/-/dot.paths-0.1.0.tgz",
-      "integrity": "sha512-JhnbIboGe8ccS+ySWEBJ7+jxLQLl9uuWZeJfBeWK49iIZdXezFptOYjP+GX9MpRrJ86nw7qNHoigi7QCiEOn7Q==",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/dot.paths/-/dot.paths-0.1.1.tgz",
+      "integrity": "sha512-9tZQg2Sye+ytLFS+HzU7PHUNeucNGVQgPwY/I2+JEhLkxpvyreIwAgXEplyZDsc611dH1vL1ELZG1pyxLNk05Q==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "dot.paths": "^0.1.0",
     "json5": "^2.2.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "dot.paths": "^0.1.0",
+    "dot.paths": "^0.1.1",
     "json5": "^2.2.3"
   },
   "devDependencies": {

--- a/test/30-types-test.js
+++ b/test/30-types-test.js
@@ -39,5 +39,6 @@ describe('TypeScript declaration checks', function () {
   it('builds declarations and typechecks public API fixtures', function () {
     runTsc(path.join(repoRoot, 'tsconfig.json'), 'build declarations');
     runTsc(path.join(repoRoot, 'test', 'type-files', 'tsconfig.json'), 'typecheck fixtures');
+    runTsc(path.join(repoRoot, 'test', 'type-files-augmented', 'tsconfig.json'), 'typecheck augmented fixtures');
   });
 });

--- a/test/type-files-augmented/config.ts
+++ b/test/type-files-augmented/config.ts
@@ -1,0 +1,30 @@
+import config = require('config');
+
+declare global {
+  namespace NodeConfig {
+    interface Schema {
+      port: number;
+      site: {
+        title: string;
+        deep: {
+          flag: boolean;
+        };
+      };
+    }
+  }
+}
+
+const port: number = config.get('port');
+const title: string = config.get('site.title');
+const flag: boolean = config.get('site.deep.flag');
+const site: { title: string; deep: { flag: boolean } } = config.get('site');
+
+const direct: string = config.site.title;
+
+const hasTyped: boolean = config.has('site.title');
+const hasUnknown: boolean = config.has('not.in.schema');
+
+// @ts-expect-error - path is not in the schema
+config.get('nope');
+// @ts-expect-error - value at 'port' is a number, not a string
+const bad: string = config.get('port');

--- a/test/type-files-augmented/config.ts
+++ b/test/type-files-augmented/config.ts
@@ -24,7 +24,8 @@ const direct: string = config.site.title;
 const hasTyped: boolean = config.has('site.title');
 const hasUnknown: boolean = config.has('not.in.schema');
 
-// @ts-expect-error - path is not in the schema
-config.get('nope');
+const explicitPort: number = config.get<number>('port');
+// @ts-expect-error - explicit generic does not bypass path checking
+config.get<number>('nope');
 // @ts-expect-error - value at 'port' is a number, not a string
 const bad: string = config.get('port');

--- a/test/type-files-augmented/tsconfig.json
+++ b/test/type-files-augmented/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strict": true,
+    "noEmit": true,
+    "baseUrl": "../..",
+    "paths": {
+      "config": ["types/lib/config.d.ts"]
+    }
+  },
+  "include": ["*.ts"]
+}

--- a/test/type-files/config.ts
+++ b/test/type-files/config.ts
@@ -2,6 +2,7 @@ import config = require('config');
 
 const hasFeature: boolean = config.has('feature.enabled');
 const port: number = config.get<number>('port');
+const inferredPort: number = config.get('port');
 const title: string = config.get<string>('site.title');
 
 const defaults = config.util.setModuleDefaults('MyModule', { enabled: true });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,6 @@
     "target": "es2020",
     "skipLibCheck": true
   },
-  "include": ["*.js", "lib/**/*.js"],
+  "include": ["*.js", "lib/**/*.js", "lib/**/*.ts"],
   "exclude": ["test/**", "tools/**", "coverage/**", "node_modules/**"]
 }


### PR DESCRIPTION
This restores (with improvements) the type safety that the previous type definitions from DefinitelyTyped provided. 

[dot.paths](https://www.npmjs.com/package/dot.paths) is my own package and is purely type definitions, it does not increase bundle size and has been rigorously benchmarked with Fable 5 to make sure that it's as performant as possible. 

Fixes #913 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added schema-aware TypeScript support for `config.get()`, including autocomplete and inferred value types for configured paths.
  * Supports nested configuration values and explicit generic type retrieval.
  * Preserved flexible string-based access when no schema is provided.

* **Tests**
  * Added coverage for typed configuration access, nested paths, property checks, and invalid paths or value types.
  * Expanded declaration compilation coverage for library types and schema-augmented configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->