### PR TITLE
fix: throw on unsupported custom env format

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1300,7 +1300,7 @@ class Load {
     if (typeof parser === 'function') {
       return parser(null, content);
     } else {
-      //TODO: throw on missing #753
+      throw new Error(`No parser found for format: ${format}`);
     }
   }
 

--- a/test/0-util.js
+++ b/test/0-util.js
@@ -1176,6 +1176,21 @@ describe('Tests for util functions', function () {
         });
       },  /__format parser error in DB_HOST: /);
     });
+
+    it('throws an error for an unsupported __format parser', function() {
+      topic.Customers.dbHost = {
+        __name: 'DB_HOST',
+        __format: 'unsupported'
+      };
+    
+      let load = new Load();
+    
+      assert.throws(function () {
+        load.substituteDeep(topic, {
+          'DB_HOST': 'example.com'
+        });
+      }, /__format parser error in DB_HOST: No parser found for format: unsupported/);
+    });
   });
 
   describe('Load.loadCustomEnvVars()', function() {


### PR DESCRIPTION
### Fixes #753.

Unsupported `__format` values in custom environment variable mappings previously returned `undefined` silently.

This change throws a descrptive error when no parser exists for the requested format and adds a regression test for the behaviour.

**Tests:**
- `npm test`
- `npm run types`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Unsupported data formats now produce a clear error instead of failing silently.
  * Error messages identify the affected variable and requested format.

* **Tests**
  * Added coverage to verify errors are raised for unsupported format parsers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->